### PR TITLE
Fix cookiecutter package.json rendering when MJML is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Various imports
 - App Config labels
 - No need for custom 404 view
+- Cookiecutter `package.json` now renders valid JSON when `use_mjml = n` (removed dangling comma in dependencies)
 
 ## [0.0.5] - 2025-10-23
 ### Added

--- a/{{ cookiecutter.project_slug }}/package.json
+++ b/{{ cookiecutter.project_slug }}/package.json
@@ -63,8 +63,7 @@
     "@stimulus-components/reveal": "^5.0.0",
     "bootstrap": "^5.1.3",
     "core-js": "^3.20.3",
-    "cssnano": "^7.0.1",
-    {% if cookiecutter.use_mjml == 'y' -%}
+    "cssnano": "^7.0.1"{% if cookiecutter.use_mjml == 'y' -%},
     "mjml": "^4.15.3"
     {% endif %}
   }


### PR DESCRIPTION
## Summary
- fix dangling comma in `{{ cookiecutter.project_slug }}/package.json` dependencies block
- keep valid JSON for both `use_mjml = y` and `use_mjml = n`
- update `CHANGELOG.md` under Unreleased > Fixed

## Why
Projects generated with `use_mjml = n` currently produce an invalid `package.json` (trailing comma), which breaks `npm install` and CI Docker builds.