### PR TITLE
Remove gunicorn --reload from production entrypoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - App Config labels
 - No need for custom 404 view
 - Cookiecutter `package.json` now renders valid JSON when `use_mjml = n` (removed dangling comma in dependencies)
+- Production Gunicorn command no longer uses `--reload` in `deployment/entrypoint.sh`
 
 ## [0.0.5] - 2025-10-23
 ### Added

--- a/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
@@ -32,7 +32,7 @@ shift $((OPTIND - 1))
 if [ "$server" = true ]; then
     python manage.py collectstatic --noinput
     python manage.py migrate
-    gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2 --reload
+    gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
 else
     python manage.py qcluster
 fi


### PR DESCRIPTION
## Summary\n- remove `--reload` from production Gunicorn command in template entrypoint\n- update `CHANGELOG.md` under Unreleased > Fixed\n\n## Why\n`--reload` is for development only and should not run in production containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Changes

* **Chores**
  * Updated production deployment configuration to prevent automatic code reloading during runtime, ensuring stable server operation in production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->