### PR TITLE
fix: dark-mode styling for auth templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Cookiecutter `package.json` now renders valid JSON when `use_mjml = n` (removed dangling comma in dependencies)
 - Production Gunicorn command no longer uses `--reload` in `deployment/entrypoint.sh`
 - Cookiecutter base templates now include dark-mode aware header/nav/mobile/footer styling classes
+- Cookiecutter auth templates (`login`, `signup`, `password_reset`) now include dark-mode friendly text/input/border styling
 
 ## [0.0.5] - 2025-10-23
 ### Added

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
@@ -6,10 +6,10 @@
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
         <div class="space-y-8 w-full max-w-md">
             <div>
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
+                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">
                     Sign in to your account
                 </h2>
-                <p class="mt-2 text-sm text-center text-gray-600">
+                <p class="mt-2 text-sm text-center text-gray-600 dark:text-gray-300">
                     Or
                     <a href="{% raw %}{% url 'account_signup' %}{%- endraw %}" class="font-medium text-{{cookiecutter.project_main_color}}-600 hover:text-{{cookiecutter.project_main_color}}-500">
                         sign up if you don't have one yet.
@@ -24,12 +24,12 @@
                     <div>
                         {{ "{{ form.login.errors | safe }}" }}
                         <label for="username" class="sr-only">Username</label>
-                        {{ '{% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
+                        {{ '{% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
                     </div>
                     <div>
                         {{ "{{ form.password.errors | safe }}" }}
                         <label for="password" class="sr-only">Password</label>
-                        {{ '{% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" placeholder="Password" %}' }}
+                        {{ '{% render_field form.password id="password" name="password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-b-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" placeholder="Password" %}' }}
                     </div>
                 </div>
 
@@ -69,10 +69,10 @@
             <div>
               <div class="relative mt-10">
                 <div class="flex absolute inset-0 items-center" aria-hidden="true">
-                  <div class="w-full border-t border-gray-200"></div>
+                  <div class="w-full border-t border-gray-200 dark:border-gray-700"></div>
                 </div>
                 <div class="flex relative justify-center text-sm font-medium leading-6">
-                  <span class="px-6 text-gray-900 bg-white">Or continue with</span>
+                  <span class="px-6 text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900">Or continue with</span>
                 </div>
               </div>
 
@@ -80,7 +80,7 @@
                 {{ "{% if 'github' in available_social_providers %}" }}
                 <form method="post" action="{% raw %}{% provider_login_url 'github' %}{%- endraw %}">
                   {{ "{% csrf_token %}" }}
-                  <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent">
+                  <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent dark:text-gray-100 dark:bg-gray-900 dark:ring-gray-700 dark:hover:bg-gray-800">
                     <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                       <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
                     </svg>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/password_reset.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/password_reset.html
@@ -5,10 +5,10 @@
     <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
         <div class="space-y-8 w-full max-w-md">
             <div>
-                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
+                <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">
                     Reset your password
                 </h2>
-                <p class="mt-2 text-sm text-center text-gray-600">
+                <p class="mt-2 text-sm text-center text-gray-600 dark:text-gray-300">
                     Enter your email address and we'll send you a link to reset your password.
                 </p>
             </div>
@@ -20,7 +20,7 @@
                     <div>
                         {{ "{{ form.email.errors | safe }}" }}
                         <label for="email" class="sr-only">Email address</label>
-                        {{ '{% render_field form.email placeholder="Email address" id="email" name="email" type="email" autocomplete="email" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-md border border-gray-300 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
+                        {{ '{% render_field form.email placeholder="Email address" id="email" name="email" type="email" autocomplete="email" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
                     </div>
                 </div>
 

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
@@ -6,10 +6,10 @@
 <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
   <div class="space-y-8 w-full max-w-md">
       <div>
-          <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900">
+          <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">
               Create your account
           </h2>
-          <p class="mt-2 text-sm text-center text-gray-600">
+          <p class="mt-2 text-sm text-center text-gray-600 dark:text-gray-300">
             Or
             <a href="{% raw %}{% url 'account_login' %}{%- endraw %}" class="font-medium text-{{cookiecutter.project_main_color}}-600 hover:text-{{cookiecutter.project_main_color}}-500">
                 login if you have one already.
@@ -25,22 +25,22 @@
           <div>
             {{ "{{ form.username.errors | safe }}" }}
             <label for="username" class="sr-only">Username</label>
-            {% raw %}{% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-t-md border border-gray-300 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            {% raw %}{% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
           </div>
           <div>
             {{ "{{ form.email.errors | safe }}" }}
             <label for="email" class="sr-only">Username</label>
-            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
           </div>
           <div>
             {{ "{{ form.password1.errors | safe }}" }}
             <label for="password1" class="sr-only">Password</label>
-            {% raw %}{% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none border border-gray-300 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            {% raw %}{% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
           </div>
           <div>
             {{ "{{ form.password2.errors | safe }}" }}
             <label for="password2" class="sr-only">Password</label>
-            {% raw %}{% render_field form.password2 id="password2" name="password2" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 rounded-none rounded-b-md border border-gray-300 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" placeholder="Cofirm Password" %}{%- endraw %}
+            {% raw %}{% render_field form.password2 id="password2" name="password2" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-b-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" placeholder="Cofirm Password" %}{%- endraw %}
           </div>
         </div>
 
@@ -72,10 +72,10 @@
       <div>
         <div class="relative mt-10">
           <div class="flex absolute inset-0 items-center" aria-hidden="true">
-            <div class="w-full border-t border-gray-200"></div>
+            <div class="w-full border-t border-gray-200 dark:border-gray-700"></div>
           </div>
           <div class="flex relative justify-center text-sm font-medium leading-6">
-            <span class="px-6 text-gray-900 bg-white">Or continue with</span>
+            <span class="px-6 text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900">Or continue with</span>
           </div>
         </div>
 
@@ -83,7 +83,7 @@
           {{ "{% if 'github' in available_social_providers %}" }}
           <form method="post" action="{% raw %}{% provider_login_url 'github' %}{%- endraw %}">
             {{ "{% csrf_token %}" }}
-            <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent">
+            <button class="flex gap-3 justify-center items-center px-3 py-2 w-full text-sm font-semibold text-gray-900 bg-white rounded-md ring-1 ring-inset ring-gray-300 shadow-sm hover:bg-gray-50 focus-visible:ring-transparent dark:text-gray-100 dark:bg-gray-900 dark:ring-gray-700 dark:hover:bg-gray-800">
               <svg class="h-5 w-5 fill-[#24292F]" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
                 <path fill-rule="evenodd" d="M10 0C4.477 0 0 4.484 0 10.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0110 4.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.203 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.942.359.31.678.921.678 1.856 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0020 10.017C20 4.484 15.522 0 10 0z" clip-rule="evenodd" />
               </svg>


### PR DESCRIPTION
## Summary
- fix dark-mode readability in cookiecutter auth templates:
  - `account/login.html`
  - `account/signup.html`
  - `account/password_reset.html`
- add dark variants for headings, helper copy, input backgrounds/text, borders, and social auth section
- update CHANGELOG

## Notes
- keeps generated projects consistent with recent dark-mode header/footer improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Dark mode styling added to all authentication templates (login, signup, and password reset). Improvements include enhanced text colors, input field backgrounds, placeholder text visibility, border colors, and social login button styling to provide better visual contrast and improved usability in dark mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->