### PR TITLE
fix: dark-mode styling on settings template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Cookiecutter `package.json` now renders valid JSON when `use_mjml = n` (removed dangling comma in dependencies)
 - Production Gunicorn command no longer uses `--reload` in `deployment/entrypoint.sh`
 - Cookiecutter base templates now include dark-mode aware header/nav/mobile/footer styling classes
+- Cookiecutter auth templates now include dark-mode friendly contrast updates
+- Cookiecutter settings template and confirm-email warning banner now include dark-mode friendly contrast updates
 
 ## [0.0.5] - 2025-10-23
 ### Added

--- a/{{ cookiecutter.project_slug }}/frontend/templates/components/confirm-email.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/components/confirm-email.html
@@ -1,5 +1,5 @@
 {{ "{% if not email_verified %}" }}
-<div class="p-4 m-4 mt-8 bg-yellow-50 rounded-md border-2 border-yellow-400">
+<div class="p-4 m-4 mt-8 bg-yellow-50 rounded-md border-2 border-yellow-400 dark:bg-yellow-900/20 dark:border-yellow-700">
   <div class="flex">
     <div class="flex-shrink-0">
       <!-- Heroicon name: mini/exclamation-triangle -->
@@ -8,13 +8,13 @@
       </svg>
     </div>
     <div class="ml-3">
-      <h3 class="text-sm font-medium text-yellow-800">Attention</h3>
-      <div class="mt-2 text-sm text-yellow-700">
+      <h3 class="text-sm font-medium text-yellow-800 dark:text-yellow-300">Attention</h3>
+      <div class="mt-2 text-sm text-yellow-700 dark:text-yellow-200">
         <form method="post" action="{% raw %}{{ resend_confirmation_url }}{%- endraw %}">
             {{ "{% csrf_token %}" }}
             <p>Your email is not yet confirmed. This will limit the available functionality.</p>
             <p>You should have gotten a link to confirm in your email. If you haven't received it,
-            <button type="submit" class="inline font-semibold text-yellow-800 underline">click here to resend</button>
+            <button type="submit" class="inline font-semibold text-yellow-800 underline dark:text-yellow-300">click here to resend</button>
           </form>
         </p>
       </div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
@@ -7,9 +7,9 @@
 {{ "{% endblock meta %}" }}
 
 {{ "{% block content %}" }}
-  <div class="container px-4 py-8 mx-auto max-w-3xl bg-white lg:min-w-0 md:pt-10 lg:flex-1">
+  <div class="container px-4 py-8 mx-auto max-w-3xl bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 lg:min-w-0 md:pt-10 lg:flex-1">
     {{ '{% include "components/confirm-email.html" with email_verified=email_verified %}' }}
-    <div class="p-4 border-t border-b border-gray-200 sm:p-6 lg:p-8 xl:border-t-0">
+    <div class="p-4 border-t border-b border-gray-200 dark:border-gray-700 sm:p-6 lg:p-8 xl:border-t-0">
       <div class="flex justify-between items-center">
         <h1 class="flex-1 pt-2 text-xl font-medium">Settings</h1>
       </div>
@@ -17,8 +17,8 @@
     {% if cookiecutter.use_stripe == 'y' -%}
     {{ "{% if not has_subscription %}" }}
     <div class="p-6 mt-6 mb-8 bg-gray-50 rounded-lg">
-      <h3 class="mb-4 text-lg font-medium leading-6 text-gray-900">Upgrade Your Account</h3>
-      <p class="mb-4 text-sm text-gray-600">Choose a plan that suits your needs:</p>
+      <h3 class="mb-4 text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">Upgrade Your Account</h3>
+      <p class="mb-4 text-sm text-gray-600 dark:text-gray-300">Choose a plan that suits your needs:</p>
       <div class="grid grid-cols-1 gap-4 md:grid-cols-3">
         <div class="rounded-md shadow">
           <a href="{% raw %}{% url 'user_upgrade_checkout_session' pk=user.id plan='monthly' %}{%- endraw %}"
@@ -49,7 +49,7 @@
 
       <div class="px-6 py-4">
         <div class="flex flex-col">
-          <h3 class="mb-6 text-lg font-medium leading-6 text-gray-900">Personal Information</h3>
+          <h3 class="mb-6 text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">Personal Information</h3>
           <div class="mt-5 md:mt-0">
             <div class="overflow-hidden sm:rounded-md">
               <div class="px-2 py-5">
@@ -57,14 +57,14 @@
                   {{ "{{ form.non_field_errors }}" }}
                   <div class="col-span-6 sm:col-span-3">
                     {{ "{{ form.first_name.errors | safe }}" }}
-                    <label for="{% raw %}{{ form.first_name.id_for_label }}{%- endraw %}" class="block text-sm font-medium text-gray-700">First name</label>
-                    {{ '{% render_field form.first_name id="first-name" name="first-name" type="text" autocomplete="given-name" class="block mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-{{ cookiecutter.project_main_color }}-500 focus:ring-{{ cookiecutter.project_main_color }}-500 sm:text-sm" %}' }}
+                    <label for="{% raw %}{{ form.first_name.id_for_label }}{%- endraw %}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">First name</label>
+                    {{ '{% render_field form.first_name id="first-name" name="first-name" type="text" autocomplete="given-name" class="block mt-1 w-full rounded-md border-gray-300 bg-white text-gray-900 shadow-sm focus:border-{{ cookiecutter.project_main_color }}-500 focus:ring-{{ cookiecutter.project_main_color }}-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-{{ cookiecutter.project_main_color }}-400 dark:focus:ring-{{ cookiecutter.project_main_color }}-400 sm:text-sm" %}' }}
                   </div>
 
                   <div class="col-span-6 sm:col-span-3">
                     {{ "{{ form.last_name.errors | safe }}" }}
-                    <label for="{% raw %}{{ form.last_name.id_for_label }}{%- endraw %}" class="block text-sm font-medium text-gray-700">Last name</label>
-                    {{ '{% render_field form.last_name id="last-name" name="last-name" type="text" autocomplete="family-name" class="block mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-{{ cookiecutter.project_main_color }}-500 focus:ring-{{ cookiecutter.project_main_color }}-500 sm:text-sm" %}' }}
+                    <label for="{% raw %}{{ form.last_name.id_for_label }}{%- endraw %}" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Last name</label>
+                    {{ '{% render_field form.last_name id="last-name" name="last-name" type="text" autocomplete="family-name" class="block mt-1 w-full rounded-md border-gray-300 bg-white text-gray-900 shadow-sm focus:border-{{ cookiecutter.project_main_color }}-500 focus:ring-{{ cookiecutter.project_main_color }}-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 dark:focus:border-{{ cookiecutter.project_main_color }}-400 dark:focus:ring-{{ cookiecutter.project_main_color }}-400 sm:text-sm" %}' }}
                   </div>
                 </div>
               </div>
@@ -75,13 +75,13 @@
 
       <div class="block" aria-hidden="true">
         <div class="py-5">
-          <div class="border-t border-gray-200"></div>
+          <div class="border-t border-gray-200 dark:border-gray-700"></div>
         </div>
       </div>
 
       <div class="px-6 py-4">
         <div class="mt-6 text-right">
-          <button type="submit" class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-{{ cookiecutter.project_main_color }}-600 rounded-md border border-transparent shadow-sm hover:bg-{{ cookiecutter.project_main_color }}-700 focus:outline-none focus:ring-2 focus:ring-{{ cookiecutter.project_main_color }}-500 focus:ring-offset-2">
+          <button type="submit" class="inline-flex justify-center px-4 py-2 text-sm font-medium text-white bg-{{ cookiecutter.project_main_color }}-600 rounded-md border border-transparent shadow-sm hover:bg-{{ cookiecutter.project_main_color }}-700 focus:outline-none focus:ring-2 focus:ring-{{ cookiecutter.project_main_color }}-500 focus:ring-offset-2 dark:focus:ring-{{ cookiecutter.project_main_color }}-400 dark:focus:ring-offset-gray-900">
             Save Changes
           </button>
         </div>


### PR DESCRIPTION
## Summary
- fix dark-mode contrast on cookiecutter settings page
- update settings form labels/inputs/dividers for dark backgrounds
- improve confirm-email warning banner readability in dark mode
- update CHANGELOG


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced dark mode styling across authentication templates with improved contrast
  * Added dark mode visual enhancements to the confirm-email alert component
  * Updated user settings page with dark mode styling and color adjustments for improved visibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->