### PR TITLE
Healthcheck: return boolean healthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Healthcheck endpoint now returns boolean `healthy` (instead of string statuses) for simpler monitoring integrations
 - Various imports
 - App Config labels
 - No need for custom 404 view


### PR DESCRIPTION
Implements Todoist task: [P2 D1] Healthcheck endpoint: return boolean true instead of string 'healthy'

- Task: 6ffW2w2J9X3VjhwM
- URL: https://app.todoist.com/app/task/p2-d1-healthcheck-endpoint-return-boolean-true-instead-of-string-healthy-6ffW2w2J9X3VjhwM

## What
- Change `/healthcheck` response shape to use booleans: `{ "healthy": true|false, "checks": { "database": bool, "redis": bool } }`.
- Update CHANGELOG.

## Why
- Makes healthcheck consumption trivial for LBs/scripts (no string parsing).

## How to test
- Generate a project from this starter and hit `GET /healthcheck`.
- With DB + Redis up: expect `200` and `{ "healthy": true, ... }`.
- With either DB or Redis down: expect `503` and `{ "healthy": false, ... }`.
