### PR TITLE
Docs: add local dev getting started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ## [Unreleased]
 ### Added
 - Added Docs Section
+- Added “Getting started (local dev)” instructions to the root README
 - Added Password Reset functinoality
 - Added banner model to make it easy to create banners for specific Referrers.
 - Added EmailSent model to keep track of all the emails sent to users.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,38 @@
 
 Generate a project with Cookiecutter:
 
-`cookiecutter git@github.com:rasulkireev/django-saas-starter.git`
+```bash
+cookiecutter git@github.com:rasulkireev/django-saas-starter.git
+```
+
+## Getting started (local dev)
+
+### Prereqs
+- Docker + Docker Compose
+- Cookiecutter (`pipx install cookiecutter` or similar)
+
+### Run
+From your newly-generated project directory:
+
+```bash
+# 1) Create your env file
+cp .env.example .env
+
+# 2) Boot everything (db/redis/backend/frontend/mailhog)
+make serve
+```
+
+Then:
+- App: http://localhost:8000
+- Mailhog inbox: http://localhost:8025
+
+### Common commands
+```bash
+make test
+make migrate
+make makemigrations
+make shell
+```
 
 ## Features
 


### PR DESCRIPTION
Implements Todoist: [P0 D2] Add getting started doc (local dev)

Task: 6fRjmPQWxqR7859M
URL: https://app.todoist.com/app/task/p0-d2-add-getting-started-doc-local-dev-6fRjmPQWxqR7859M

## What
- Add a short, copy-pastable local dev quickstart to the root README.
- Add changelog entry.

## Why
- Make first-run and contributor onboarding faster (no hunting for Make targets / ports).

## How to test
1) Generate a new project via cookiecutter.
2) In the generated directory:
   - `cp .env.example .env`
   - `make serve`
3) Visit http://localhost:8000 and Mailhog at http://localhost:8025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added a comprehensive Getting Started section with prerequisite requirements, step-by-step run instructions, and example outputs to help users quickly set up the project locally.
- Improved documentation formatting by converting inline commands into properly formatted code blocks for enhanced readability and clarity.
- Reorganized README structure for better user guidance on local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->