### PR TITLE
Fix Docker images: don"t require uv.lock by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Docker deployment images no longer fail to build when `uv.lock` is missing (the default in freshly-generated projects)
 - Healthcheck endpoint now returns boolean `healthy` (instead of string statuses) for simpler monitoring integrations
 - Various imports
 - App Config labels

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
@@ -14,9 +14,11 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 RUN pip install --no-cache-dir uv
-RUN uv sync --frozen --no-dev --no-install-project
+# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
+# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
+RUN uv sync --no-dev --no-install-project
 
 COPY . .
 COPY --from=build /app/frontend/build/ ./frontend/build/

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
@@ -14,9 +14,11 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 RUN pip install --no-cache-dir uv
-RUN uv sync --frozen --no-dev --no-install-project
+# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
+# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
+RUN uv sync --no-dev --no-install-project
 
 COPY . .
 COPY --from=build /app/frontend/build/ ./frontend/build/


### PR DESCRIPTION
### Why
The template Dockerfiles copy `uv.lock`, but newly-generated projects don’t include one, so `docker build` fails out of the box.

### What
- Stop copying `uv.lock` during image builds
- Run `uv sync` without `--frozen` so builds work for fresh projects
- Document reproducible-build path in Dockerfiles (generate + commit `uv.lock`, then re-add `--frozen`)
- Update CHANGELOG

### Notes
No behavior change for projects that already commit a `uv.lock` (they can re-enable `--frozen` if desired).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved Docker deployment failures for freshly-generated projects when uv.lock is absent. Both server and worker deployment images now build successfully out-of-the-box without requiring a pre-existing lock file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->