### PR TITLE
docs: explain /apps directory apps in generated README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - updated dj-stripe and stripe versions
 - default timeout for tassk to be around an hour
 - moved all apps to apps directory
+- docs: generated project README now explains what each `/apps/*` package is for (helps humans + AI place code correctly)
 - move `core` and `pages` apps into `apps` directory.
 - remove djstripe. only use strip for payments
 - Use psycopg-binary instead of psycopg2-binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Docker deployment images no longer fail to build when `uv.lock` is missing (the default in freshly-generated projects)
 - Healthcheck endpoint now returns boolean `healthy` (instead of string statuses) for simpler monitoring integrations
 - Various imports
 - App Config labels

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -14,6 +14,16 @@
 
 - Add info about your project here
 
+### Project structure: `/apps`
+
+This project keeps Django apps inside the `/apps` directory. This is both for human clarity and to help AI/code assistants put code in the right place.
+
+- `apps/core`: main app functionality (shared domain logic, base models, services, etc.)
+- `apps/docs`: user-facing documentation
+- `apps/api`: all API needs (Django Ninja routers, schemas, API-specific logic)
+- `apps/pages`: landing/marketing pages (pricing, TOS, privacy policy, etc.)
+- `apps/blog`: user-facing blog
+
 ***
 
 ## TOC

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
@@ -14,9 +14,11 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 RUN pip install --no-cache-dir uv
-RUN uv sync --frozen --no-dev --no-install-project
+# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
+# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
+RUN uv sync --no-dev --no-install-project
 
 COPY . .
 COPY --from=build /app/frontend/build/ ./frontend/build/

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
@@ -14,9 +14,11 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml uv.lock ./
+COPY pyproject.toml ./
 RUN pip install --no-cache-dir uv
-RUN uv sync --frozen --no-dev --no-install-project
+# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
+# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
+RUN uv sync --no-dev --no-install-project
 
 COPY . .
 COPY --from=build /app/frontend/build/ ./frontend/build/


### PR DESCRIPTION
Updates the generated project README to describe the purpose of each Django app under /apps (core/docs/api/pages/blog). This is meant to improve human onboarding and help AI assistants place code correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced project README with explanations of the Django application structure and sub-packages.

* **Bug Fixes**
  * Resolved Docker deployment build failures in fresh project environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->