### PR TITLE
feat: navbar theme toggle (dark/light)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ## [Unreleased]
 ### Added
+- Dark/light mode toggle in navbar (generated projects)
 - pytest-based tests for the Cookiecutter template (generate projects + assert file structure)
 - Refresh root README for clarity and stronger positioning
 - Optional GitHub Actions CI workflow in generated projects (Django checks + pytest on pull requests)

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -14,6 +14,10 @@
 
 - Add info about your project here
 
+### Theme
+
+This template includes a dark/light mode toggle in the navbar. The preference is stored in `localStorage` and applied early to avoid a flash of incorrect theme.
+
 ### Project structure: `/apps`
 
 This project keeps Django apps inside the `/apps` directory. This is both for human clarity and to help AI/code assistants put code in the right place.

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/theme_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/theme_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from "@hotwired/stimulus";
+
+const STORAGE_KEY = "theme";
+
+function preferredTheme() {
+  if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    return "dark";
+  }
+  return "light";
+}
+
+function currentTheme() {
+  return localStorage.getItem(STORAGE_KEY) || preferredTheme();
+}
+
+function applyTheme(theme) {
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}
+
+export default class extends Controller {
+  static targets = ["iconLight", "iconDark", "label"]; // all optional
+
+  connect() {
+    applyTheme(currentTheme());
+    this.updateUI();
+  }
+
+  toggle() {
+    const next = currentTheme() === "dark" ? "light" : "dark";
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+    this.updateUI();
+  }
+
+  updateUI() {
+    const theme = currentTheme();
+
+    if (this.hasIconLightTarget) this.iconLightTarget.classList.toggle("hidden", theme !== "light");
+    if (this.hasIconDarkTarget) this.iconDarkTarget.classList.toggle("hidden", theme !== "dark");
+
+    if (this.hasLabelTarget) {
+      this.labelTarget.textContent = theme === "dark" ? "Dark" : "Light";
+    }
+
+    this.element.setAttribute(
+      "aria-label",
+      theme === "dark" ? "Switch to light mode" : "Switch to dark mode",
+    );
+  }
+}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -50,6 +50,25 @@
   {{ "{% endif %}" }}
   {% endif %}
 
+  <script>
+    // Set theme early to avoid a flash of incorrect theme.
+    (function () {
+      try {
+        var theme = localStorage.getItem("theme");
+        if (!theme) {
+          theme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        if (theme === "dark") {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
+      } catch (e) {
+        // no-op
+      }
+    })();
+  </script>
+
   {{ "{% stylesheet_pack 'index' %}" }}
   {{ "{% javascript_pack 'index' attrs='defer' %}" }}
 </head>
@@ -102,6 +121,31 @@
 
           <!-- Desktop Auth Buttons -->
           <div class="flex gap-2 items-center ml-auto">
+            <button
+              type="button"
+              data-controller="theme"
+              data-action="theme#toggle"
+              class="hidden lg:inline-flex justify-center items-center w-11 h-11 rounded-full border border-gray-200 bg-white text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+              aria-label="Toggle theme"
+            >
+              <span class="sr-only" data-theme-target="label">Theme</span>
+              <!-- Sun (light) -->
+              <svg data-theme-target="iconLight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5">
+                <circle cx="12" cy="12" r="4" />
+                <path d="M12 2v2" />
+                <path d="M12 20v2" />
+                <path d="M4.93 4.93l1.41 1.41" />
+                <path d="M17.66 17.66l1.41 1.41" />
+                <path d="M2 12h2" />
+                <path d="M20 12h2" />
+                <path d="M4.93 19.07l1.41-1.41" />
+                <path d="M17.66 6.34l1.41-1.41" />
+              </svg>
+              <!-- Moon (dark) -->
+              <svg data-theme-target="iconDark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden w-5 h-5">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+              </svg>
+            </button>
             {{ "{% if user.is_authenticated %}" }}
             <form method="post" action="{% raw %}{% url 'account_logout' %}{%- endraw %}" class="hidden lg:block">
               {{ "{% csrf_token %}" }}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -50,6 +50,25 @@
   {{ "{% endif %}" }}
   {% endif %}
 
+  <script>
+    // Set theme early to avoid a flash of incorrect theme.
+    (function () {
+      try {
+        var theme = localStorage.getItem("theme");
+        if (!theme) {
+          theme = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+        }
+        if (theme === "dark") {
+          document.documentElement.classList.add("dark");
+        } else {
+          document.documentElement.classList.remove("dark");
+        }
+      } catch (e) {
+        // no-op
+      }
+    })();
+  </script>
+
   {{ "{% stylesheet_pack 'index' %}" }}
   {{ "{% javascript_pack 'index' attrs='defer' %}" }}
 </head>
@@ -109,6 +128,31 @@
 
           <!-- Desktop Auth Buttons -->
           <div class="hidden gap-2 items-center ml-auto lg:flex">
+            <button
+              type="button"
+              data-controller="theme"
+              data-action="theme#toggle"
+              class="inline-flex justify-center items-center w-11 h-11 rounded-full border border-gray-200 bg-white text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
+              aria-label="Toggle theme"
+            >
+              <span class="sr-only" data-theme-target="label">Theme</span>
+              <!-- Sun (light) -->
+              <svg data-theme-target="iconLight" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5">
+                <circle cx="12" cy="12" r="4" />
+                <path d="M12 2v2" />
+                <path d="M12 20v2" />
+                <path d="M4.93 4.93l1.41 1.41" />
+                <path d="M17.66 17.66l1.41 1.41" />
+                <path d="M2 12h2" />
+                <path d="M20 12h2" />
+                <path d="M4.93 19.07l1.41-1.41" />
+                <path d="M17.66 6.34l1.41-1.41" />
+              </svg>
+              <!-- Moon (dark) -->
+              <svg data-theme-target="iconDark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="hidden w-5 h-5">
+                <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+              </svg>
+            </button>
             {{ "{% if user.is_authenticated %}" }}
               <a href="{% raw %}{% url 'home' %}{%- endraw %}" class="inline-block rounded-full border-[1.5px] border-gray-300 px-6 py-3 text-sm font-semibold text-gray-900 hover:bg-gray-100 dark:border-gray-700 dark:text-gray-100 dark:hover:bg-gray-800">Dashboard</a>
             {{ "{% else %}" }}


### PR DESCRIPTION
Adds a dark/light mode toggle to the navbar in generated projects.

Details:
- New Stimulus controller: `frontend/src/controllers/theme_controller.js`
- Theme is persisted in `localStorage` (`theme=dark|light`)
- An early inline script applies the theme on page load to avoid flashes
- Toggle button added to both `base_app.html` and `base_landing.html`
- Generated project README updated with a short note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dark/light mode toggle in navbar for seamless theme switching with preference persistence

* **Documentation**
  * Updated CHANGELOG and README with new Theme section documenting the dark/light mode toggle functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->