### PR TITLE
fix: remove hard-coded rasulkireev.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ## [Unreleased]
 ### Added
 - Dark/light mode toggle in navbar (generated projects)
+- `author_url` cookiecutter variable (replaces hard-coded rasulkireev.com)
 - pytest-based tests for the Cookiecutter template (generate projects + assert file structure)
 - Refresh root README for clarity and stronger positioning
 - Optional GitHub Actions CI workflow in generated projects (Django checks + pytest on pull requests)

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,7 @@
   "project_description": "This project will help you be the best in the world",
   "author_name": "Jane Doe",
   "author_email": "janedoe@example.com",
+  "author_url": "https://example.com",
   "project_main_color": "green",
   "use_posthog": "y",
   "use_buttondown": "y",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,7 +5,7 @@
   "project_description": "This project will help you be the best in the world",
   "author_name": "Jane Doe",
   "author_email": "janedoe@example.com",
-  "author_url": "https://example.com",
+  "author_url": "",
   "project_main_color": "green",
   "use_posthog": "y",
   "use_buttondown": "y",

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -17,6 +17,7 @@ def _generate(tmp_path: Path, **extra_context: str) -> Path:
         "project_description": "Test Project Description",
         "author_name": "Ada Lovelace",
         "author_email": "ada@example.com",
+        "author_url": "https://example.com",
         "project_main_color": "green",
         # defaults (can be overridden per test)
         "use_posthog": "n",
@@ -176,6 +177,9 @@ def test_use_posthog_toggles_posthog_snippet(tmp_path: Path) -> None:
 
 def test_generated_project_does_not_contain_unrendered_cookiecutter_vars(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path)
+
+    _assert_not_contains(project_dir / "frontend" / "templates" / "base_app.html", "rasulkireev.com")
+    _assert_not_contains(project_dir / "frontend" / "templates" / "base_landing.html", "rasulkireev.com")
 
     # Some frontend templates intentionally embed Cookiecutter variables inside Django-template
     # string literals (so they are not evaluated by Cookiecutter). We keep this test as a

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -17,7 +17,7 @@ def _generate(tmp_path: Path, **extra_context: str) -> Path:
         "project_description": "Test Project Description",
         "author_name": "Ada Lovelace",
         "author_email": "ada@example.com",
-        "author_url": "https://example.com",
+        "author_url": "",
         "project_main_color": "green",
         # defaults (can be overridden per test)
         "use_posthog": "n",
@@ -178,8 +178,15 @@ def test_use_posthog_toggles_posthog_snippet(tmp_path: Path) -> None:
 def test_generated_project_does_not_contain_unrendered_cookiecutter_vars(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path)
 
-    _assert_not_contains(project_dir / "frontend" / "templates" / "base_app.html", "rasulkireev.com")
-    _assert_not_contains(project_dir / "frontend" / "templates" / "base_landing.html", "rasulkireev.com")
+    base_app = project_dir / "frontend" / "templates" / "base_app.html"
+    base_landing = project_dir / "frontend" / "templates" / "base_landing.html"
+
+    _assert_not_contains(base_app, "rasulkireev.com")
+    _assert_not_contains(base_landing, "rasulkireev.com")
+
+    # When author_url is empty, it should not be rendered into JSON-LD as an empty string.
+    _assert_not_contains(base_app, '"url": ""')
+    _assert_not_contains(base_landing, '"url": ""')
 
     # Some frontend templates intentionally embed Cookiecutter variables inside Django-template
     # string literals (so they are not evaluated by Cookiecutter). We keep this test as a

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -257,8 +257,8 @@
       "url": "https://{{ '{{ request.get_host }}' }}/",
       "author": {
         "@type": "Person",
-        "name": "{{ cookiecutter.author_name }}",
-        "url": "{{ cookiecutter.author_url }}"
+        "name": "{{ cookiecutter.author_name }}"{% if cookiecutter.author_url %},
+        "url": "{{ cookiecutter.author_url }}"{% endif %}
       }
     }
     </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -258,7 +258,7 @@
       "author": {
         "@type": "Person",
         "name": "{{ cookiecutter.author_name }}",
-        "url": "https://rasulkireev.com/"
+        "url": "{{ cookiecutter.author_url }}"
       }
     }
     </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -263,8 +263,8 @@
       "url": "https://{{ '{{ request.get_host }}' }}/",
       "author": {
         "@type": "Person",
-        "name": "{{ cookiecutter.author_name }}",
-        "url": "{{ cookiecutter.author_url }}"
+        "name": "{{ cookiecutter.author_name }}"{% if cookiecutter.author_url %},
+        "url": "{{ cookiecutter.author_url }}"{% endif %}
       }
     }
     </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -264,7 +264,7 @@
       "author": {
         "@type": "Person",
         "name": "{{ cookiecutter.author_name }}",
-        "url": "https://rasulkireev.com/"
+        "url": "{{ cookiecutter.author_url }}"
       }
     }
     </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_post.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_post.html
@@ -49,8 +49,8 @@
     "dateModified": "{% raw %}{{ blog_post.updated_at|date:'c' }}{% endraw %}",
     "author": {
       "@type": "Person",
-      "name": "{{ cookiecutter.author_name }}",
-      "url": "{{ cookiecutter.author_url }}"
+      "name": "{{ cookiecutter.author_name }}"{% if cookiecutter.author_url %},
+      "url": "{{ cookiecutter.author_url }}"{% endif %}
     },
     "publisher": {
       "@type": "Organization",

--- a/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_post.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_post.html
@@ -50,7 +50,7 @@
     "author": {
       "@type": "Person",
       "name": "{{ cookiecutter.author_name }}",
-      "url": "https://rasulkireev.com/"
+      "url": "{{ cookiecutter.author_url }}"
     },
     "publisher": {
       "@type": "Organization",

--- a/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_posts.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_posts.html
@@ -61,8 +61,8 @@
     "url": "https://{% raw %}{{ request.get_host }}{% endraw %}{% raw %}{% url 'blog_posts' %}{% endraw %}",
     "author": {
       "@type": "Person",
-      "name": "{{ cookiecutter.author_name }}",
-      "url": "{{ cookiecutter.author_url }}"
+      "name": "{{ cookiecutter.author_name }}"{% if cookiecutter.author_url %},
+      "url": "{{ cookiecutter.author_url }}"{% endif %}
     }
   }
   </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_posts.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/blog/blog_posts.html
@@ -62,7 +62,7 @@
     "author": {
       "@type": "Person",
       "name": "{{ cookiecutter.author_name }}",
-      "url": "https://rasulkireev.com/"
+      "url": "{{ cookiecutter.author_url }}"
     }
   }
   </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/pricing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/pricing.html
@@ -157,8 +157,8 @@
     "url": "{% raw %}https://{{ request.get_host }}{% url 'pricing' %}{%- endraw %}",
     "author": {
       "@type": "Person",
-      "name": "{{ cookiecutter.author_name }}",
-      "url": "{{ cookiecutter.author_url }}"
+      "name": "{{ cookiecutter.author_name }}"{% if cookiecutter.author_url %},
+      "url": "{{ cookiecutter.author_url }}"{% endif %}
     }
   }
   </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/pricing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/pricing.html
@@ -158,7 +158,7 @@
     "author": {
       "@type": "Person",
       "name": "{{ cookiecutter.author_name }}",
-      "url": "https://rasulkireev.com/"
+      "url": "{{ cookiecutter.author_url }}"
     }
   }
   </script>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/uses.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/uses.html
@@ -25,7 +25,7 @@
         <h1>Tech I Use</h1>
         <p>
           I run
-          <a href="https://www.rasulkireev.com/projects">multiple projects</a>
+          <a href="{{ cookiecutter.author_url }}">multiple projects</a>
           at the same time and using reliable and simple tech is the key to running everything smoothly. Here's what I use:
         </p>
         <ul>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/uses.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/uses.html
@@ -25,7 +25,11 @@
         <h1>Tech I Use</h1>
         <p>
           I run
+          {% if cookiecutter.author_url %}
           <a href="{{ cookiecutter.author_url }}">multiple projects</a>
+          {% else %}
+          multiple projects
+          {% endif %}
           at the same time and using reliable and simple tech is the key to running everything smoothly. Here's what I use:
         </p>
         <ul>


### PR DESCRIPTION
Removes hard-coded references to rasulkireev.com from the Cookiecutter template.

- Introduces a new cookiecutter variable: `author_url` (optional; may be empty)
- Uses `author_url` in JSON-LD author blocks (base templates, blog, pricing) only when provided
- Updates `uses.html` so it no longer points to rasulkireev.com (renders a link only if `author_url` is set)
- Adds a regression assertion in template tests to ensure rasulkireev.com does not appear in generated base templates
