### PR TITLE
feat: account deletion (danger zone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ## [Unreleased]
 ### Added
+- Ability for users to permanently delete their account (Danger Zone modal in settings)
 - Dark/light mode toggle in navbar (generated projects)
 - `author_url` cookiecutter variable (replaces hard-coded rasulkireev.com)
 - pytest-based tests for the Cookiecutter template (generate projects + assert file structure)

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -74,6 +74,10 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     assert (project_dir / "pyproject.toml").exists()
     assert (project_dir / "frontend" / "templates").exists()
 
+    # new feature: account deletion flow
+    assert (project_dir / "apps" / "core" / "tests" / "test_delete_account.py").exists()
+    _assert_contains(project_dir / "apps" / "core" / "urls.py", "delete-account")
+
     # apps present by default
     assert (project_dir / "apps" / "core").exists()
     assert (project_dir / "apps" / "pages").exists()

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_delete_account.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_delete_account.py
@@ -1,0 +1,26 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_delete_account_requires_confirmation(auth_client, user):
+    url = reverse("delete_account")
+
+    response = auth_client.post(url, data={"confirmation": "nope"})
+    assert response.status_code == 302
+
+    # user should still exist
+    assert get_user_model().objects.filter(id=user.id).exists()
+
+
+@pytest.mark.django_db
+def test_delete_account_deletes_user(auth_client, user):
+    url = reverse("delete_account")
+
+    response = auth_client.post(url, data={"confirmation": "DELETE"})
+
+    assert response.status_code == 302
+    assert response["Location"].startswith(reverse("landing"))
+
+    assert not get_user_model().objects.filter(id=user.id).exists()

--- a/{{ cookiecutter.project_slug }}/apps/core/urls.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
     path("admin-panel", views.AdminPanelView.as_view(), name="admin_panel"),
     # Utils
     path("resend-confirmation/", views.resend_confirmation_email, name="resend_confirmation"),
+    path("delete-account/", views.delete_account, name="delete_account"),
     {% if cookiecutter.use_stripe == 'y' -%}
     # Payments
     path("stripe-webhook/", views.stripe_webhook, name="stripe_webhook"),

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/delete_account_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/delete_account_controller.js
@@ -1,0 +1,29 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["modal", "confirmation", "submit"]; // submit optional
+
+  open() {
+    if (!this.hasModalTarget) return;
+    this.modalTarget.classList.remove("hidden");
+    this.modalTarget.classList.add("flex");
+
+    if (this.hasConfirmationTarget) {
+      this.confirmationTarget.value = "";
+      this.confirmationTarget.focus();
+    }
+
+    this.update();
+  }
+
+  close() {
+    if (!this.hasModalTarget) return;
+    this.modalTarget.classList.add("hidden");
+    this.modalTarget.classList.remove("flex");
+  }
+
+  update() {
+    if (!this.hasSubmitTarget || !this.hasConfirmationTarget) return;
+    this.submitTarget.disabled = this.confirmationTarget.value !== "DELETE";
+  }
+}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/landing-page.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/landing-page.html
@@ -2,6 +2,13 @@
 
 {{ "{% block content %}" }}
 <div class="isolate relative px-6 mt-16 sm:mt-24 lg:px-8">
+
+  {{ "{% if request.GET.account_deleted %}" }}
+  <div class="mx-auto mb-10 max-w-3xl rounded-xl border border-green-200 bg-green-50 p-4 text-sm text-green-800 dark:border-green-900/40 dark:bg-green-950/30 dark:text-green-200">
+    Your account has been deleted.
+  </div>
+  {{ "{% endif %}" }}
+
   <div class="isolate relative px-6 mt-16 sm:mt-24 lg:px-8">
     <div class="mx-auto text-center">
         <h1 class="mx-auto mb-6 max-w-2xl text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
@@ -88,5 +88,83 @@
       </div>
     </form>
 
+    <!-- Danger Zone -->
+    <div class="mt-10 rounded-lg border border-red-200 bg-red-50 p-6 dark:border-red-900/50 dark:bg-red-950/30" data-controller="delete-account">
+      <div class="flex items-start justify-between gap-6">
+        <div>
+          <h3 class="text-lg font-semibold text-red-900 dark:text-red-200">Danger Zone</h3>
+          <p class="mt-1 text-sm text-red-800/80 dark:text-red-200/80">
+            Deleting your account is irreversible. This will permanently delete your user record and related data from the database.
+          </p>
+        </div>
+        <button
+          type="button"
+          data-action="delete-account#open"
+          class="inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        >
+          Delete account
+        </button>
+      </div>
+
+      <!-- Modal -->
+      <div
+        data-delete-account-target="modal"
+        class="hidden fixed inset-0 z-50 items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Delete account confirmation"
+      >
+        <div class="absolute inset-0 bg-black/50" data-action="click->delete-account#close"></div>
+
+        <div class="relative mx-4 w-full max-w-lg rounded-2xl border border-gray-200 bg-white p-6 shadow-xl dark:border-gray-800 dark:bg-gray-900">
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h4 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Delete account</h4>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                This action is irreversible. To confirm, type <span class="font-mono font-semibold">DELETE</span> below.
+              </p>
+            </div>
+            <button type="button" class="rounded-md p-1 text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-100" data-action="delete-account#close" aria-label="Close">
+              <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <form method="post" action="{% raw %}{% url 'delete_account' %}{% endraw %}" class="mt-6 space-y-4">
+            {{ "{% csrf_token %}" }}
+
+            <div>
+              <label for="delete-confirmation" class="block text-sm font-medium text-gray-700 dark:text-gray-300">Confirmation</label>
+              <input
+                id="delete-confirmation"
+                name="confirmation"
+                type="text"
+                autocomplete="off"
+                data-delete-account-target="confirmation"
+                data-action="input->delete-account#update"
+                placeholder="Type DELETE"
+                class="mt-1 block w-full rounded-md border-gray-300 bg-white text-gray-900 shadow-sm focus:border-red-500 focus:ring-red-500 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+              />
+            </div>
+
+            <div class="flex items-center justify-end gap-3">
+              <button type="button" class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800" data-action="delete-account#close">
+                Cancel
+              </button>
+              <button
+                type="submit"
+                data-delete-account-target="submit"
+                disabled
+                class="inline-flex items-center rounded-md bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm disabled:cursor-not-allowed disabled:opacity-50 hover:bg-red-700"
+              >
+                Yes, delete my account
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+
   </div>
 {{ "{% endblock content %}" }}


### PR DESCRIPTION
Adds a safe, explicit “delete my account” flow to generated projects.

- Settings page now has a **Danger Zone** section.
- Clicking “Delete account” opens a modal that requires typing `DELETE`.
- New POST endpoint: `/delete-account/` (login required, POST-only)
  - Deletes the user record (and related data via cascades)
  - Logs the user out
  - Redirects to landing with `?account_deleted=1`
- Landing page shows a simple confirmation banner when `account_deleted=1`.
- Adds Django tests for the deletion view + asserts the route exists in the cookiecutter template tests.

