### PR TITLE
test: prevent maintainer-specific literal leaks in generated output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Added a regression test that scans generated projects for maintainer-specific hard-coded literals (e.g., `rasulkireev.com`, `Rasul`) to keep template output generic and reusable.
 - Docker deployment images no longer fail to build when `uv.lock` is missing (the default in freshly-generated projects)
 - Healthcheck endpoint now returns boolean `healthy` (instead of string statuses) for simpler monitoring integrations
 - Various imports

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -221,3 +221,26 @@ def test_generated_project_does_not_contain_unrendered_cookiecutter_vars(tmp_pat
             offenders.append(str(rel))
 
     assert offenders == [], f"Unrendered cookiecutter vars found in: {offenders}"
+
+
+def test_generated_project_does_not_contain_template_author_leaks(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path)
+
+    banned_literals = ("rasulkireev.com", "Rasul")
+    offenders: list[str] = []
+
+    for path in project_dir.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.suffix in {".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2"}:
+            continue
+
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+
+        if any(token in text for token in banned_literals):
+            offenders.append(str(path.relative_to(project_dir)))
+
+    assert offenders == [], f"Hard-coded template author literals found in: {offenders}"


### PR DESCRIPTION
## Summary
Adds a regression guard to keep generated projects generic and reusable by preventing maintainer-specific literal leaks.

## What changed
- Added `test_generated_project_does_not_contain_template_author_leaks` to scan generated files for hard-coded literals like `rasulkireev.com` and `Rasul`.
- Updated `CHANGELOG.md` (Unreleased → Fixed).

## Why
Recent improvements removed hard-coded maintainer values. This test ensures they do not accidentally reappear in future template changes.

## Validation
- `uv sync --group test`
- `uv run --group test python -m pytest tests/test_cookiecutter_template.py -k 'author_leaks or unrendered_cookiecutter_vars'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test to verify generated projects remain free of author-specific hard-coded values, ensuring template output stays generic and reusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->