### PR TITLE
Fix theme toggle click binding in template base layouts

### DIFF
--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -124,7 +124,7 @@
             <button
               type="button"
               data-controller="theme"
-              data-action="theme#toggle"
+              data-action="click->theme#toggle"
               class="hidden lg:inline-flex justify-center items-center w-11 h-11 rounded-full border border-gray-200 bg-white text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
               aria-label="Toggle theme"
             >

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -131,7 +131,7 @@
             <button
               type="button"
               data-controller="theme"
-              data-action="theme#toggle"
+              data-action="click->theme#toggle"
               class="inline-flex justify-center items-center w-11 h-11 rounded-full border border-gray-200 bg-white text-gray-900 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800"
               aria-label="Toggle theme"
             >


### PR DESCRIPTION
## Summary
- update Stimulus theme toggle action binding in base templates from implicit `theme#toggle` to explicit `click->theme#toggle`
- apply to both `base_landing.html` and `base_app.html` in cookiecutter template

## Why
This makes the event wiring explicit and consistent, preventing toggle click behavior regressions in generated projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved theme toggle button functionality by refining event handling across the application. The toggle now responds specifically to click events, ensuring more reliable and predictable behavior when switching between light and dark modes. This targeted approach enhances consistency throughout all interface pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->