### PR TITLE
Carry dark-mode + CI import/fixture fixes into template

### DIFF
--- a/{{ cookiecutter.project_slug }}/apps/core/stripe_webhooks.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/stripe_webhooks.py
@@ -2,8 +2,8 @@ import stripe
 from django.conf import settings
 
 from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
-from core.choices import ProfileStates
-from core.models import Profile
+from apps.core.choices import ProfileStates
+from apps.core.models import Profile
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
 

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_signals.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_signals.py
@@ -1,8 +1,8 @@
 import pytest
 from django.contrib.auth import get_user_model
 
-from core.choices import ProfileStates
-from core.models import Profile
+from apps.core.choices import ProfileStates
+from apps.core.models import Profile
 
 
 @pytest.mark.django_db

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_stripe_webhooks.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_stripe_webhooks.py
@@ -1,13 +1,13 @@
 import pytest
 
-from core.choices import ProfileStates
-from core.models import Profile
-from core.stripe_webhooks import (
+from apps.core.choices import ProfileStates
+from apps.core.models import Profile
+from apps.core.stripe_webhooks import (
     handle_created_subscription,
     handle_deleted_subscription,
     handle_updated_subscription,
 )
-from core.tests.test_helpers import build_subscription_event
+from apps.core.tests.test_helpers import build_subscription_event
 
 
 @pytest.mark.django_db

--- a/{{ cookiecutter.project_slug }}/apps/core/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/views.py
@@ -20,7 +20,7 @@ from django.urls import reverse, reverse_lazy
 from django.views.generic import TemplateView, UpdateView
 
 {% if cookiecutter.use_stripe == 'y' -%}
-from core.stripe_webhooks import EVENT_HANDLERS
+from apps.core.stripe_webhooks import EVENT_HANDLERS
 {% endif %}
 
 from apps.core.forms import ProfileUpdateForm

--- a/{{ cookiecutter.project_slug }}/tailwind.config.js
+++ b/{{ cookiecutter.project_slug }}/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class',
   content: [
     './frontend/templates/**/*.html',
     './core/**/*.py',

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -543,7 +543,7 @@ MJML_HTTPSERVERS = [
 
 SHELL_PLUS_IMPORTS = [
     "from django_q.tasks import async_task",
-    "from core.tasks import *",
+    "from apps.core.tasks import *",
 ]
 
 


### PR DESCRIPTION
## Summary
- set template Tailwind config to `darkMode: 'class'` so HTML-class theme toggles work reliably
- normalize `core.*` imports to `apps.core.*` in template tests and stripe modules
- add missing `sync_state_transitions` fixture in template tests and handle django-q `group` kwarg
- align shell-plus import path to `apps.core.tasks`

## Why
These are follow-up hardening changes discovered while fixing dark-mode and CI in djass, so newly generated projects inherit the same fixes out of the box.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized module import paths across the application for improved code structure.
  * Enabled dark mode support through CSS class configuration in Tailwind.

* **Tests**
  * Added test fixture for state transition tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->