### PR TITLE
Add passkey auth to generated projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 - Fix pricing page dark mode styles.
 ### Added
+- Passkey authentication (WebAuthn) in generated projects: sign in + sign up flows via `django-allauth` MFA.
 - Ability for users to permanently delete their account (Danger Zone modal in settings)
 - Dark/light mode toggle in navbar (generated projects)
 - `author_url` cookiecutter variable (replaces hard-coded rasulkireev.com)

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -99,6 +99,39 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     json.loads(_read_text(project_dir / "package.json"))
 
 
+def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path)
+
+    settings_py = project_dir / "test_project" / "settings.py"
+    urls_py = project_dir / "test_project" / "urls.py"
+    views_py = project_dir / "apps" / "pages" / "views.py"
+
+    _assert_contains(project_dir / "pyproject.toml", "fido2>=1.1.2,<3")
+    _assert_contains(settings_py, '"allauth.mfa"')
+    _assert_contains(settings_py, 'ACCOUNT_EMAIL_VERIFICATION = "mandatory"')
+    _assert_contains(settings_py, "ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True")
+    _assert_contains(settings_py, "MFA_PASSKEY_LOGIN_ENABLED = True")
+    _assert_contains(settings_py, "MFA_PASSKEY_SIGNUP_ENABLED = True")
+    _assert_contains(settings_py, "MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG")
+
+    _assert_contains(urls_py, "accounts/signup/passkey/")
+    _assert_contains(urls_py, "account_signup_by_passkey")
+    _assert_contains(views_py, "AccountSignupByPasskeyView")
+
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "login.html",
+        "Sign in with a passkey",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "signup.html",
+        "Sign up using a passkey",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "signup_by_passkey.html",
+        "Continue with passkey",
+    )
+
+
 def test_generate_without_blog_removes_blog_app_and_templates(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path, generate_blog="n")
 

--- a/{{ cookiecutter.project_slug }}/apps/pages/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/pages/tests.py
@@ -1,3 +1,31 @@
-from django.test import TestCase
+import pytest
+from django.urls import reverse
 
-# Create your tests here.
+
+pytestmark = pytest.mark.django_db
+
+
+def test_login_page_shows_passkey_option(client):
+    response = client.get(reverse("account_login"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Sign in with a passkey" in content
+    assert 'id="mfa_login"' in content
+
+
+def test_signup_page_shows_passkey_option(client):
+    response = client.get(reverse("account_signup"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Sign up using a passkey" in content
+
+
+def test_passkey_signup_page_uses_custom_template(client):
+    response = client.get(reverse("account_signup_by_passkey"))
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    assert "Create your account with a passkey" in content
+    assert "Continue with passkey" in content

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
@@ -56,6 +56,16 @@
                     </button>
                 </div>
 
+                {{ "{% if PASSKEY_LOGIN_ENABLED %}" }}
+                <div>
+                    <button type="button"
+                            id="passkey_login"
+                            class="flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-900 bg-white rounded-md border border-gray-300 border-solid hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{cookiecutter.project_main_color}}-500 dark:text-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800">
+                        Sign in with a passkey
+                    </button>
+                </div>
+                {{ "{% endif %}" }}
+
                 <div class="flex justify-center items-center">
                     <div class="text-sm">
                         <a href="{% raw %}{% url 'account_reset_password' %}{% endraw %}" class="font-medium text-{{cookiecutter.project_main_color}}-600 hover:text-{{cookiecutter.project_main_color}}-500">
@@ -64,6 +74,10 @@
                     </div>
                 </div>
             </form>
+
+            {{ "{% if PASSKEY_LOGIN_ENABLED %}" }}
+                {{ '{% include "mfa/webauthn/snippets/login_script.html" with button_id="passkey_login" %}' }}
+            {{ "{% endif %}" }}
 
             {{ "{% if has_social_providers %}" }}
             <div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
@@ -68,6 +68,26 @@
         </div>
       </form>
 
+      {{ "{% if PASSKEY_SIGNUP_ENABLED %}" }}
+      <div>
+        <div class="relative mt-10">
+          <div class="flex absolute inset-0 items-center" aria-hidden="true">
+            <div class="w-full border-t border-gray-200 dark:border-gray-700"></div>
+          </div>
+          <div class="flex relative justify-center text-sm font-medium leading-6">
+            <span class="px-6 text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900">Passkey</span>
+          </div>
+        </div>
+
+        <div class="mt-6">
+          <a href="{% raw %}{{ signup_by_passkey_url }}{%- endraw %}"
+             class="flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-900 bg-white rounded-md border border-gray-300 border-solid hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{cookiecutter.project_main_color}}-500 dark:text-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800">
+            Sign up using a passkey
+          </a>
+        </div>
+      </div>
+      {{ "{% endif %}" }}
+
       {{ "{% if has_social_providers %}" }}
       <div>
         <div class="relative mt-10">

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/signup_by_passkey.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/signup_by_passkey.html
@@ -1,0 +1,63 @@
+{{ '{% extends "base_landing.html" %}' }}
+{{ "{% load widget_tweaks %}" }}
+
+{{ "{% block content %}" }}
+<div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
+  <div class="space-y-8 w-full max-w-md">
+      <div>
+          <h2 class="mt-6 text-3xl font-extrabold text-center text-gray-900 dark:text-gray-100">
+              Create your account with a passkey
+          </h2>
+          <p class="mt-2 text-sm text-center text-gray-600 dark:text-gray-300">
+            Or
+            <a href="{% raw %}{% url 'account_login' %}{%- endraw %}" class="font-medium text-{{cookiecutter.project_main_color}}-600 hover:text-{{cookiecutter.project_main_color}}-500">
+                login if you have one already.
+            </a>
+          </p>
+      </div>
+      <form class="mt-8 space-y-6" id="signup_form" method="post" action="{% raw %}{% url 'account_signup_by_passkey' %}{%- endraw %}">
+        {{ "{% csrf_token %}" }}
+
+        {{ "{{ form.non_field_errors | safe }}" }}
+        <div class="-space-y-px rounded-md shadow-sm">
+          {{ "{% if form.username %}" }}
+          <div>
+            {{ "{{ form.username.errors | safe }}" }}
+            <label for="username" class="sr-only">Username</label>
+            {% raw %}{% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+          </div>
+          {{ "{% endif %}" }}
+
+          {{ "{% if form.email %}" }}
+          <div>
+            {{ "{{ form.email.errors | safe }}" }}
+            <label for="email" class="sr-only">Email</label>
+            {{ "{% if form.username %}" }}
+            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-b-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            {{ "{% else %}" }}
+            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            {{ "{% endif %}" }}
+          </div>
+          {{ "{% endif %}" }}
+        </div>
+
+        {{ "{% if redirect_field_value %}" }}
+        <input type="hidden" name="{% raw %}{{ redirect_field_name }}{%- endraw %}" value="{% raw %}{{ redirect_field_value }}{%- endraw %}" />
+        {{ "{% endif %}" }}
+
+        <div>
+            <button type="submit"
+                    class="relative flex justify-center w-full px-4 py-2 text-sm font-medium text-white bg-{{cookiecutter.project_main_color}}-600 border border-transparent border-solid rounded-md group hover:bg-{{cookiecutter.project_main_color}}-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{cookiecutter.project_main_color}}-500">
+                Continue with passkey
+            </button>
+        </div>
+      </form>
+
+      <div>
+        <a href="{% raw %}{% url 'account_signup' %}{%- endraw %}" class="flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-900 bg-white rounded-md border border-gray-300 border-solid hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{cookiecutter.project_main_color}}-500 dark:text-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800">
+          Use password signup instead
+        </a>
+      </div>
+  </div>
+</div>
+{{ '{% endblock content %}' }}

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "django-storages>=1.14.6",
     "django-structlog>=10.0.0",
     "django-widget-tweaks>=1.5.1",
+    "fido2>=1.1.2,<3",
     "gunicorn>=25.0.1",
     "ipython>=9.10.0",
     "markdown>=3.10.1",

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -91,6 +91,7 @@ THIRD_PARTY_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.github",
+    "allauth.mfa",
     "django_q",
     "django_extensions",
     {% if cookiecutter.use_mjml == 'y' -%}
@@ -285,6 +286,8 @@ ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
+ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True
 ACCOUNT_FORMS = {
     "signup": "apps.core.forms.CustomSignUpForm",
     "login": "apps.core.forms.CustomLoginForm",
@@ -292,6 +295,13 @@ ACCOUNT_FORMS = {
 ACCOUNT_ADAPTER = "{{cookiecutter.project_slug}}.adapters.CustomAccountAdapter"
 if ENVIRONMENT != "dev":
     ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
+
+# Passkey (WebAuthn) auth support via django-allauth MFA.
+MFA_SUPPORTED_TYPES = ["webauthn"]
+MFA_PASSKEY_LOGIN_ENABLED = True
+MFA_PASSKEY_SIGNUP_ENABLED = True
+# Local dev uses http://localhost, so allow insecure origin only in debug.
+MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG
 
 SOCIALACCOUNT_AUTO_SIGNUP = True
 SOCIALACCOUNT_PROVIDERS = {}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/urls.py
@@ -19,12 +19,13 @@ from django.contrib.sitemaps.views import sitemap
 from django.views.generic import TemplateView
 
 from {{ cookiecutter.project_slug }}.sitemaps import sitemaps
-from apps.pages.views import AccountSignupView
+from apps.pages.views import AccountSignupByPasskeyView, AccountSignupView
 
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    # Override allauth signup with custom view
+    # Override allauth signup with custom views.
+    path("accounts/signup/passkey/", AccountSignupByPasskeyView.as_view(), name="account_signup_by_passkey"),
     path("accounts/signup/", AccountSignupView.as_view(), name="account_signup"),
     path("accounts/", include("allauth.urls")),
     path("anymail/", include("anymail.urls")),


### PR DESCRIPTION
## Summary
- add passkey auth support to generated projects using django-allauth MFA (WebAuthn)
- add `fido2` dependency in generated `pyproject.toml`
- enable allauth MFA app + passkey settings in generated Django settings
- add required allauth email-verification settings for passkey signup (`mandatory` + code-based verification)
- add passkey signup route/view (`/accounts/signup/passkey/`) and keep signup tracking behavior
- update account login/signup templates to surface passkey actions
- add a custom `account/signup_by_passkey.html` template

## Tests
- template repo tests:
  - `uv sync --group test`
  - `uv run python -m pytest -q`
- added regression assertions in `tests/test_cookiecutter_template.py` to ensure generated projects include passkey settings/files/UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Passkey (WebAuthn) authentication for sign in and sign up flows
  * Email verification requirement added for account security
  * New "Sign in with a passkey" option on login page
  * New "Sign up using a passkey" option on signup page
  * Dedicated passkey signup flow interface

* **Tests**
  * Added comprehensive test coverage for passkey authentication integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->