### PR TITLE
fix: add missing initial migrations for core and pages models

### DIFF
--- a/{{ cookiecutter.project_slug }}/apps/core/migrations/0002_initial_models.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/migrations/0002_initial_models.py
@@ -1,0 +1,152 @@
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+import uuid
+
+import apps.core.model_utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("core", "0001_enable_extensions"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Profile",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uuid", models.UUIDField(default=uuid.uuid4, editable=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("key", models.CharField(default=apps.core.model_utils.generate_random_key, max_length=30, unique=True)),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("stranger", "Stranger"),
+                            ("cold", "Cold"),
+                            ("warm", "Warm"),
+                            ("hot", "Hot"),
+                            ("customer", "Customer"),
+                        ],
+                        default="stranger",
+                        help_text="The current state of the user's profile",
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "user",
+                    models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name="ProfileStateTransition",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uuid", models.UUIDField(default=uuid.uuid4, editable=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "from_state",
+                    models.CharField(
+                        choices=[
+                            ("stranger", "Stranger"),
+                            ("cold", "Cold"),
+                            ("warm", "Warm"),
+                            ("hot", "Hot"),
+                            ("customer", "Customer"),
+                        ],
+                        max_length=255,
+                    ),
+                ),
+                (
+                    "to_state",
+                    models.CharField(
+                        choices=[
+                            ("stranger", "Stranger"),
+                            ("cold", "Cold"),
+                            ("warm", "Warm"),
+                            ("hot", "Hot"),
+                            ("customer", "Customer"),
+                        ],
+                        max_length=255,
+                    ),
+                ),
+                ("backup_profile_id", models.IntegerField()),
+                ("metadata", models.JSONField(blank=True, null=True)),
+                (
+                    "profile",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="state_transitions",
+                        to="core.profile",
+                    ),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name="Feedback",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uuid", models.UUIDField(default=uuid.uuid4, editable=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("feedback", models.TextField(help_text="The feedback text")),
+                ("page", models.CharField(help_text="The page where the feedback was submitted", max_length=255)),
+                (
+                    "profile",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="The user who submitted the feedback",
+                        null=True,
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="feedback",
+                        to="core.profile",
+                    ),
+                ),
+            ],
+        ),
+        migrations.CreateModel(
+            name="EmailSent",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uuid", models.UUIDField(default=uuid.uuid4, editable=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("email_address", models.EmailField(help_text="The recipient email address", max_length=254)),
+                (
+                    "email_type",
+                    models.CharField(
+                        choices=[
+                            ("welcome", "Welcome"),
+                            ("email_confirmation", "Email Confirmation"),
+                            ("feedback_notification", "Feedback Notification"),
+                        ],
+                        help_text="Type of email sent",
+                        max_length=50,
+                    ),
+                ),
+                (
+                    "profile",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text="Associated user profile, if applicable",
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="emails_sent",
+                        to="core.profile",
+                    ),
+                ),
+            ],
+            options={
+                "verbose_name": "Email Sent",
+                "verbose_name_plural": "Emails Sent",
+                "ordering": ["-created_at"],
+            },
+        ),
+    ]

--- a/{{ cookiecutter.project_slug }}/apps/pages/migrations/0001_initial.py
+++ b/{{ cookiecutter.project_slug }}/apps/pages/migrations/0001_initial.py
@@ -1,0 +1,75 @@
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = []
+
+    operations = [
+        migrations.CreateModel(
+            name="ReferrerBanner",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("uuid", models.UUIDField(default=uuid.uuid4, editable=False)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                (
+                    "referrer",
+                    models.CharField(
+                        help_text="The referrer code from URL parameter (e.g., 'producthunt' from ?ref=producthunt)",
+                        max_length=100,
+                        unique=True,
+                    ),
+                ),
+                (
+                    "referrer_printable_name",
+                    models.CharField(
+                        help_text="Human-readable name to display in banner (e.g., 'Product Hunt')",
+                        max_length=200,
+                    ),
+                ),
+                (
+                    "expiry_date",
+                    models.DateTimeField(blank=True, help_text="When to stop showing this banner", null=True),
+                ),
+                (
+                    "coupon_code",
+                    models.CharField(blank=True, help_text="Optional discount coupon code", max_length=100),
+                ),
+                (
+                    "discount_amount",
+                    models.DecimalField(
+                        decimal_places=2,
+                        default=0,
+                        help_text="Discount from 0.00 (0%) to 1.00 (100%)",
+                        max_digits=3,
+                    ),
+                ),
+                (
+                    "is_active",
+                    models.BooleanField(
+                        default=True,
+                        help_text="Manually enable/disable banner without deleting it",
+                    ),
+                ),
+                (
+                    "background_color",
+                    models.CharField(
+                        default="bg-gradient-to-r from-red-500 to-red-600",
+                        help_text="Tailwind CSS background color classes (e.g., 'bg-gradient-to-r from-red-500 to-red-600' or 'bg-blue-600')",
+                        max_length=100,
+                    ),
+                ),
+                (
+                    "text_color",
+                    models.CharField(
+                        default="text-white",
+                        help_text="Tailwind CSS text color class (e.g., 'text-white' or 'text-gray-900')",
+                        max_length=50,
+                    ),
+                ),
+            ],
+        )
+    ]


### PR DESCRIPTION
Fresh cookiecutter-generated apps currently miss migrations for core models (Profile/Feedback/etc.) and pages ReferrerBanner. This causes first-run 500s (e.g. signup and landing) on clean databases.\n\nThis PR adds:\n- apps/core/migrations/0002_initial_models.py\n- apps/pages/migrations/0001_initial.py\n\nso new projects migrate cleanly on first deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profile system with state tracking and transition history to manage user progression
  * Feedback collection system to gather user input and insights
  * Email tracking and logging system to monitor correspondence
  * Referrer banner functionality featuring customizable styling, promotional coupon codes, and expiry date management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->