### PR TITLE
docs: require all-app makemigrations before coding

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ cookiecutter git@github.com:rasulkireev/django-saas-starter.git
 
 Then follow the generated project’s `README.md` for local development + deployment.
 
+Important: in generated projects, run `python manage.py makemigrations` (without app labels) before feature work so all app model changes are captured.
+
 ## What you get (high level)
 
 ### Core

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           }
           EOF
 
+      - name: Migrations check
+        run: uv run python manage.py makemigrations --check --dry-run
+
       - name: Django checks
         run: uv run python manage.py check
 

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -124,6 +124,8 @@ You'd still need to make sure .env has correct values.
 1. Update the name of the `.env.example` to `.env` and update relevant variables.
 2. Run `uv sync`
 3. Run `uv run python manage.py makemigrations`
+   - Important: run this **without specifying app names** so Django detects changes across **all apps**.
+   - Do this before feature work and before first local run.
 4. Run `make serve`
 5. Run `make restart-worker` just in case, it sometimes has troubles connecting to REDIS on first deployment.
 
@@ -131,7 +133,7 @@ You'd still need to make sure .env has correct values.
 
 If you generated the project with `use_ci = y`, it includes a GitHub Actions workflow at `.github/workflows/ci.yml` that runs on pull requests.
 
-It boots Postgres + Redis, runs `python manage.py check`, and then runs `pytest`.
+It boots Postgres + Redis, runs `python manage.py makemigrations --check --dry-run`, then `python manage.py check`, and then runs `pytest`.
 
 If you don’t want CI, set `use_ci = n` during Cookiecutter generation and the workflow will be removed.
 


### PR DESCRIPTION
Per team workflow, cookiecutter users should always run  (without app labels) before coding/running.\n\nThis PR updates:\n- root README guidance\n- generated project README Local Development section\n- generated CI workflow to run  before checks/tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added migrations validation check to CI pipeline that verifies all pending migrations are captured before deployment.

* **Documentation**
  * Updated README with guidance on running migrations before feature work to ensure all model changes across apps are properly captured during local development and CI workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->