### PR TITLE
feat(template): add blog management API scaffold

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -28,6 +28,23 @@ This project keeps Django apps inside the `/apps` directory. This is both for hu
 - `apps/pages`: landing/marketing pages (pricing, TOS, privacy policy, etc.)
 - `apps/blog`: user-facing blog
 
+{% if cookiecutter.generate_blog == 'y' -%}
+### Blog management API endpoints (admin)
+
+When blog generation is enabled, the template includes a ready-to-extend blog post management API in `apps/api/views.py`:
+
+- `POST /api/blog-posts/submit`
+- `GET /api/internal/blog-posts`
+- `GET /api/internal/blog-posts/{blog_post_id}`
+- `PUT /api/internal/blog-posts/{blog_post_id}`
+- `PATCH /api/internal/blog-posts/{blog_post_id}`
+- `DELETE /api/internal/blog-posts/{blog_post_id}`
+- `POST /api/internal/blog-posts/{blog_post_id}/review`
+- `POST /api/internal/blog-posts/{blog_post_id}/publish`
+
+These endpoints use superuser API auth by default and are intended as a starter baseline you can adapt for your product-specific content workflows.
+{% endif %}
+
 ***
 
 ## TOC

--- a/{{ cookiecutter.project_slug }}/apps/api/schemas.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/schemas.py
@@ -26,9 +26,38 @@ class BlogPostIn(Schema):
     status: BlogPostStatus = BlogPostStatus.DRAFT
 
 
+class BlogPostUpdateIn(Schema):
+    title: Optional[str] = None
+    description: Optional[str] = None
+    slug: Optional[str] = None
+    tags: Optional[str] = None
+    content: Optional[str] = None
+    status: Optional[BlogPostStatus] = None
+
+
+class BlogPostItemOut(Schema):
+    id: int
+    title: str
+    description: str
+    slug: str
+    tags: str
+    content: str
+    status: BlogPostStatus
+
+
+class BlogPostListOut(Schema):
+    blog_posts: list[BlogPostItemOut]
+
+
 class BlogPostOut(Schema):
     status: str  # API response status: 'success' or 'failure'
     message: str
+
+
+class BlogPostDetailOut(Schema):
+    status: str
+    message: str
+    blog_post: Optional[BlogPostItemOut] = None
 {% endif %}
 
 

--- a/{{ cookiecutter.project_slug }}/apps/api/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/tests.py
@@ -1,3 +1,74 @@
-from django.test import TestCase
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
-# Create your tests here.
+from django.test import TestCase
+from django.http import HttpRequest
+
+{% if cookiecutter.generate_blog == 'y' %}
+from apps.blog.choices import BlogPostStatus
+from apps.api.views import (
+    list_internal_blog_posts,
+    get_internal_blog_post,
+    publish_internal_blog_post,
+)
+
+
+class BlogPostApiTests(TestCase):
+    @staticmethod
+    def _request() -> HttpRequest:
+        request = HttpRequest()
+        request.auth = SimpleNamespace(user=SimpleNamespace(is_superuser=True))
+        return request
+
+    def test_list_internal_blog_posts_returns_serialized_items(self):
+        request = self._request()
+        post = SimpleNamespace(
+            id=1,
+            title="Hello",
+            description="Desc",
+            slug="hello",
+            tags="django",
+            content="Body",
+            status=BlogPostStatus.DRAFT,
+            created_at=None,
+        )
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.order_by.return_value = [post]
+            response = list_internal_blog_posts(request)
+
+        assert len(response["blog_posts"]) == 1
+        assert response["blog_posts"][0]["slug"] == "hello"
+
+    def test_get_internal_blog_post_returns_404_when_missing(self):
+        request = self._request()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.get.side_effect = Exception("not found")
+            # normalize to model-specific behavior
+            from apps.blog.models import BlogPost
+
+            objects.get.side_effect = BlogPost.DoesNotExist
+            status, payload = get_internal_blog_post(request, blog_post_id=999)
+
+        assert status == 404
+        assert payload["message"] == "Blog post not found."
+
+    def test_publish_internal_blog_post_sets_status_to_published(self):
+        request = self._request()
+        post = Mock()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.get.return_value = post
+            response = publish_internal_blog_post(request, blog_post_id=12)
+
+        assert response["status"] == "success"
+        assert post.status == BlogPostStatus.PUBLISHED
+        post.save.assert_called_once()
+{% else %}
+
+
+class PlaceholderApiTests(TestCase):
+    def test_placeholder(self):
+        assert True
+{% endif %}

--- a/{{ cookiecutter.project_slug }}/apps/api/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/views.py
@@ -8,13 +8,18 @@ from apps.api.auth import session_auth, superuser_api_auth
 from apps.core.models import Feedback
 {% if cookiecutter.generate_blog == 'y' -%}
 from apps.blog.models import BlogPost
+from apps.blog.choices import BlogPostStatus
 {% endif -%}
 from apps.api.schemas import (
     SubmitFeedbackIn,
     SubmitFeedbackOut,
     {%- if cookiecutter.generate_blog == 'y' %}
     BlogPostIn,
+    BlogPostUpdateIn,
+    BlogPostItemOut,
+    BlogPostListOut,
     BlogPostOut,
+    BlogPostDetailOut,
     {% endif -%}
     ProfileSettingsOut,
     UserSettingsOut,
@@ -113,6 +118,18 @@ def submit_feedback(request: HttpRequest, data: SubmitFeedbackIn):
 
 
 {% if cookiecutter.generate_blog == 'y' %}
+def _serialize_blog_post(blog_post: BlogPost) -> BlogPostItemOut:
+    return {
+        "id": blog_post.id,
+        "title": blog_post.title,
+        "description": blog_post.description,
+        "slug": blog_post.slug,
+        "tags": blog_post.tags,
+        "content": blog_post.content,
+        "status": blog_post.status,
+    }
+
+
 @api.post(
     "/blog-posts/submit",
     response=BlogPostOut,
@@ -139,6 +156,155 @@ def submit_blog_post(request: HttpRequest, data: BlogPostIn):
         return BlogPostOut(status="success", message="Blog post submitted successfully.")
     except Exception as e:
         return BlogPostOut(status="failure", message=f"Failed to submit blog post: {str(e)}")
+
+
+@api.get(
+    "/internal/blog-posts",
+    response=BlogPostListOut,
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def list_internal_blog_posts(request: HttpRequest):
+    blog_posts = BlogPost.objects.order_by("-created_at")
+    return {"blog_posts": [_serialize_blog_post(blog_post) for blog_post in blog_posts]}
+
+
+@api.get(
+    "/internal/blog-posts/{blog_post_id}",
+    response={200: BlogPostDetailOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def get_internal_blog_post(request: HttpRequest, blog_post_id: int):
+    try:
+        blog_post = BlogPost.objects.get(id=blog_post_id)
+    except BlogPost.DoesNotExist:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    return {
+        "status": "success",
+        "message": "Blog post retrieved successfully.",
+        "blog_post": _serialize_blog_post(blog_post),
+    }
+
+
+@api.put(
+    "/internal/blog-posts/{blog_post_id}",
+    response={200: BlogPostDetailOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def update_internal_blog_post(request: HttpRequest, blog_post_id: int, data: BlogPostIn):
+    try:
+        blog_post = BlogPost.objects.get(id=blog_post_id)
+    except BlogPost.DoesNotExist:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    blog_post.title = data.title
+    blog_post.description = data.description
+    blog_post.slug = data.slug
+    blog_post.tags = data.tags
+    blog_post.content = data.content
+    blog_post.status = data.status
+    blog_post.save(update_fields=["title", "description", "slug", "tags", "content", "status", "updated_at"])
+
+    return {
+        "status": "success",
+        "message": "Blog post updated successfully.",
+        "blog_post": _serialize_blog_post(blog_post),
+    }
+
+
+@api.patch(
+    "/internal/blog-posts/{blog_post_id}",
+    response={200: BlogPostDetailOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def patch_internal_blog_post(request: HttpRequest, blog_post_id: int, data: BlogPostUpdateIn):
+    try:
+        blog_post = BlogPost.objects.get(id=blog_post_id)
+    except BlogPost.DoesNotExist:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    fields_to_update = []
+    for field in ["title", "description", "slug", "tags", "content", "status"]:
+        value = getattr(data, field)
+        if value is not None:
+            setattr(blog_post, field, value)
+            fields_to_update.append(field)
+
+    if fields_to_update:
+        blog_post.save(update_fields=[*fields_to_update, "updated_at"])
+
+    return {
+        "status": "success",
+        "message": "Blog post updated successfully.",
+        "blog_post": _serialize_blog_post(blog_post),
+    }
+
+
+@api.delete(
+    "/internal/blog-posts/{blog_post_id}",
+    response={200: BlogPostOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def delete_internal_blog_post(request: HttpRequest, blog_post_id: int):
+    deleted_count, _ = BlogPost.objects.filter(id=blog_post_id).delete()
+    if deleted_count == 0:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    return {"status": "success", "message": "Blog post deleted successfully."}
+
+
+@api.post(
+    "/internal/blog-posts/{blog_post_id}/review",
+    response={200: BlogPostDetailOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def review_internal_blog_post(request: HttpRequest, blog_post_id: int):
+    try:
+        blog_post = BlogPost.objects.get(id=blog_post_id)
+    except BlogPost.DoesNotExist:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    blog_post.status = BlogPostStatus.DRAFT
+    blog_post.save(update_fields=["status", "updated_at"])
+    return {
+        "status": "success",
+        "message": "Blog post moved to draft for review.",
+        "blog_post": _serialize_blog_post(blog_post),
+    }
+
+
+@api.post(
+    "/internal/blog-posts/{blog_post_id}/publish",
+    response={200: BlogPostDetailOut, 404: BlogPostOut},
+    auth=[superuser_api_auth],
+    include_in_schema=False,
+    tags=["admin"],
+)
+def publish_internal_blog_post(request: HttpRequest, blog_post_id: int):
+    try:
+        blog_post = BlogPost.objects.get(id=blog_post_id)
+    except BlogPost.DoesNotExist:
+        return 404, {"status": "error", "message": "Blog post not found."}
+
+    blog_post.status = BlogPostStatus.PUBLISHED
+    blog_post.save(update_fields=["status", "updated_at"])
+    return {
+        "status": "success",
+        "message": "Blog post published successfully.",
+        "blog_post": _serialize_blog_post(blog_post),
+    }
 {% endif %}
 
 @api.get(


### PR DESCRIPTION
## Summary
Adds a reusable blog post management API scaffold to generated projects (when `generate_blog = y`).

### New endpoints
- `POST /api/blog-posts/submit`
- `GET /api/internal/blog-posts`
- `GET /api/internal/blog-posts/{blog_post_id}`
- `PUT /api/internal/blog-posts/{blog_post_id}`
- `PATCH /api/internal/blog-posts/{blog_post_id}`
- `DELETE /api/internal/blog-posts/{blog_post_id}`
- `POST /api/internal/blog-posts/{blog_post_id}/review`
- `POST /api/internal/blog-posts/{blog_post_id}/publish`

## Implementation details
- Extended API schemas for list/detail/update payloads.
- Added serialization helper + CRUD/review/publish handlers in `apps/api/views.py`.
- Added template README section documenting the blog management API.
- Added API tests in template app.

## Verification
- `uv run --group test pytest -q` (passes)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added internal blog administration API endpoints with full CRUD support for blog posts
  * Added review and publish action endpoints for blog post workflow management
  * Updated documentation with API endpoint specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->