### PR TITLE
fix: render footer year dynamically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,3 +131,6 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 ### Fixed
 - close button on messages now works fine
+
+## Unreleased
+- Make shared footer and auth email footer years render dynamically instead of hardcoding 2025.

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/email/account_already_exists_message.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/email/account_already_exists_message.html
@@ -102,7 +102,7 @@
     <mj-section background-color="#f3f4f6" padding="20px">
       <mj-column>
         <mj-text font-size="12px" color="#9ca3af" align="center">
-          © 2025 {{ cookiecutter.project_name }}. All rights reserved.
+          © {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.
         </mj-text>
       </mj-column>
     </mj-section>
@@ -145,7 +145,7 @@
     </div>
 
     <div style="text-align: center; padding: 20px; color: #9ca3af; font-size: 12px;">
-        <p>© 2025 {{ cookiecutter.project_name }}. All rights reserved.</p>
+        <p>© {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.</p>
     </div>
 </body>
 </html>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/email/email_confirmation_message.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/email/email_confirmation_message.html
@@ -99,7 +99,7 @@
     <mj-section background-color="#f3f4f6" padding="20px">
       <mj-column>
         <mj-text font-size="12px" color="#9ca3af" align="center">
-          © 2025 {{ cookiecutter.project_name }}. All rights reserved.
+          © {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.
         </mj-text>
       </mj-column>
     </mj-section>
@@ -141,7 +141,7 @@
     </div>
 
     <div style="text-align: center; padding: 20px; color: #9ca3af; font-size: 12px;">
-        <p>© 2025 {{ cookiecutter.project_name }}. All rights reserved.</p>
+        <p>© {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.</p>
     </div>
 </body>
 </html>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/email/email_confirmation_signup_message.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/email/email_confirmation_signup_message.html
@@ -99,7 +99,7 @@
     <mj-section background-color="#f3f4f6" padding="20px">
       <mj-column>
         <mj-text font-size="12px" color="#9ca3af" align="center">
-          © 2025 {{ cookiecutter.project_name }}. All rights reserved.
+          © {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.
         </mj-text>
       </mj-column>
     </mj-section>
@@ -141,7 +141,7 @@
     </div>
 
     <div style="text-align: center; padding: 20px; color: #9ca3af; font-size: 12px;">
-        <p>© 2025 {{ cookiecutter.project_name }}. All rights reserved.</p>
+        <p>© {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.</p>
     </div>
 </body>
 </html>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/email/password_reset_key_message.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/email/password_reset_key_message.html
@@ -99,7 +99,7 @@
     <mj-section background-color="#f3f4f6" padding="20px">
       <mj-column>
         <mj-text font-size="12px" color="#9ca3af" align="center">
-          © 2025 {{ cookiecutter.project_name }}. All rights reserved.
+          © {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.
         </mj-text>
       </mj-column>
     </mj-section>
@@ -141,7 +141,7 @@
     </div>
 
     <div style="text-align: center; padding: 20px; color: #9ca3af; font-size: 12px;">
-        <p>© 2025 {{ cookiecutter.project_name }}. All rights reserved.</p>
+        <p>© {% raw %}{% now "Y" %}{% endraw %} {{ cookiecutter.project_name }}. All rights reserved.</p>
     </div>
 </body>
 </html>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -238,7 +238,7 @@
       <div class="px-6 py-12 mx-auto max-w-7xl md:flex md:items-center md:justify-between lg:px-8">
         <div class="mt-8 md:mt-0">
           <p class="text-xs leading-5 text-center text-gray-500 dark:text-gray-400">
-            &copy; 2025 <a href="https://lvtd.dev?ref={{ '{{ request.get_host }}' }}">LVTD, LLC</a>. All rights reserved.
+            &copy; {% raw %}{% now "Y" %}{% endraw %} <a href="https://lvtd.dev?ref={{ '{{ request.get_host }}' }}">LVTD, LLC</a>. All rights reserved.
           </p>
         </div>
       </div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -244,7 +244,7 @@
         </div>
         <div class="mt-8 md:order-1 md:mt-0">
           <p class="text-xs leading-5 text-center text-gray-500 dark:text-gray-400">
-            &copy; 2025 <a href="https://lvtd.dev?ref={{ '{{ request.get_host }}' }}">LVTD, LLC</a>. All rights reserved.
+            &copy; {% raw %}{% now "Y" %}{% endraw %} <a href="https://lvtd.dev?ref={{ '{{ request.get_host }}' }}">LVTD, LLC</a>. All rights reserved.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace hardcoded `2025` footer years with Django's `{% now "Y" %}` in shared app/landing templates
- do the same for auth email templates, including the plain HTML fallback copies
- update CHANGELOG for the footer-year fix

## Verification
- `find '{{ cookiecutter.project_slug }}/frontend/templates' \( -path '{{ cookiecutter.project_slug }}/frontend/templates/base_app.html' -o -path '{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html' -o -path '{{ cookiecutter.project_slug }}/frontend/templates/account/email/*' \) -type f -print0 | xargs -0 grep -n '2025' || true`
- remaining `2025` hits are only unrelated default date literals, not footer years


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Copyright year in email footers and website footers now renders dynamically, automatically updating each year instead of displaying a fixed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->