### PR TITLE
Harden transactional email delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - npm lint command
 
 ### Changed
+- Transactional email delivery in generated projects now retries transient failures, emits structured observability fields/counters, and avoids bubbling email send errors into user-facing 500s for confirmation + feedback flows.
 - Upgraded generated frontend stack from Tailwind CSS v3 to v4 using `@tailwindcss/postcss` and v4 CSS directives.
 - Updated generated deployment Dockerfiles to use Node 22 build stage (required for Tailwind v4 toolchain compatibility).
 - Root README now reflects Django 6 + Python 3.14

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -88,6 +88,13 @@ def test_generate_default_structure(tmp_path: Path) -> None:
         'dark:bg-red-950/40',
     )
 
+    # transactional email hardening should ship in generated projects
+    assert (project_dir / "apps" / "core" / "tests" / "test_email_delivery.py").exists()
+    _assert_contains(
+        project_dir / "apps" / "core" / "utils.py",
+        'def send_transactional_email(',
+    )
+
     # optional apps on by default in this test helper
     assert (project_dir / "apps" / "blog").exists()
     assert (project_dir / "apps" / "docs").exists()
@@ -110,6 +117,7 @@ def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
     _assert_contains(settings_py, '"allauth.mfa"')
     _assert_contains(settings_py, 'ACCOUNT_EMAIL_VERIFICATION = "mandatory"')
     _assert_contains(settings_py, "ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True")
+    _assert_contains(settings_py, "EMAIL_DELIVERY_RETRY_BACKOFF_SECONDS = (0.0, 1.0, 3.0)")
     _assert_contains(settings_py, "MFA_PASSKEY_LOGIN_ENABLED = True")
     _assert_contains(settings_py, "MFA_PASSKEY_SIGNUP_ENABLED = True")
     _assert_contains(settings_py, "MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG")

--- a/{{ cookiecutter.project_slug }}/apps/core/models.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/models.py
@@ -5,11 +5,13 @@ from django.contrib.auth.models import User
 from django.db import models
 from django.urls import reverse
 from django.conf import settings
+from django.core.mail import send_mail
 from django_q.tasks import async_task
 
 from apps.core.base_models import BaseModel
 from apps.core.choices import ProfileStates, EmailType
 from apps.core.model_utils import generate_random_key
+from apps.core.utils import send_transactional_email
 
 
 from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
@@ -107,11 +109,6 @@ class Feedback(BaseModel):
         super().save(*args, **kwargs)
 
         if is_new:
-            from django.conf import settings
-            from django.core.mail import send_mail
-
-            from apps.core.utils import track_email_sent
-
             subject = "New Feedback Submitted"
             message = f"""
                 New feedback was submitted:\n\n
@@ -122,13 +119,22 @@ class Feedback(BaseModel):
             from_email = settings.DEFAULT_FROM_EMAIL
             recipient_list = [settings.DEFAULT_FROM_EMAIL]
 
-            send_mail(subject, message, from_email, recipient_list, fail_silently=True)
-
             for recipient_email in recipient_list:
-                track_email_sent(
+                send_transactional_email(
+                    lambda recipient=recipient_email: send_mail(
+                        subject,
+                        message,
+                        from_email,
+                        [recipient],
+                        fail_silently=False,
+                    ),
                     email_address=recipient_email,
                     email_type=EmailType.FEEDBACK_NOTIFICATION,
                     profile=self.profile,
+                    context={
+                        "flow": "feedback_notification",
+                        "feedback_id": self.id,
+                    },
                 )
 
 class EmailSent(BaseModel):

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_email_delivery.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_email_delivery.py
@@ -1,0 +1,121 @@
+from types import SimpleNamespace
+
+import pytest
+from allauth.account.adapter import DefaultAccountAdapter
+
+from apps.core.choices import EmailType
+from apps.core.models import EmailSent, Feedback
+from apps.core.utils import (
+    EMAIL_DELIVERY_METRICS,
+    get_email_delivery_provider,
+    send_transactional_email,
+)
+from {{ cookiecutter.project_slug }}.adapters import CustomAccountAdapter
+
+
+@pytest.mark.django_db
+def test_send_transactional_email_tracks_success(profile):
+    EMAIL_DELIVERY_METRICS.clear()
+    attempts = []
+
+    def send_callable():
+        attempts.append("sent")
+
+    success = send_transactional_email(
+        send_callable,
+        email_address=profile.user.email,
+        email_type=EmailType.WELCOME,
+        profile=profile,
+        retry_backoff_seconds=(0.0,),
+    )
+
+    assert success is True
+    assert attempts == ["sent"]
+    assert EmailSent.objects.filter(email_address=profile.user.email).count() == 1
+    provider = get_email_delivery_provider()
+    assert EMAIL_DELIVERY_METRICS[f"{EmailType.WELCOME}:{provider}:success"] == 1
+
+
+@pytest.mark.django_db
+def test_send_transactional_email_retries_transient_failures(profile):
+    EMAIL_DELIVERY_METRICS.clear()
+    attempts = {"count": 0}
+
+    def send_callable():
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise TimeoutError("temporary email outage")
+
+    success = send_transactional_email(
+        send_callable,
+        email_address=profile.user.email,
+        email_type=EmailType.EMAIL_CONFIRMATION,
+        profile=profile,
+        retry_backoff_seconds=(0.0, 0.0),
+    )
+
+    assert success is True
+    assert attempts["count"] == 2
+    provider = get_email_delivery_provider()
+    assert EMAIL_DELIVERY_METRICS[f"{EmailType.EMAIL_CONFIRMATION}:{provider}:retrying"] == 1
+    assert EMAIL_DELIVERY_METRICS[f"{EmailType.EMAIL_CONFIRMATION}:{provider}:success"] == 1
+
+
+@pytest.mark.django_db
+def test_send_transactional_email_returns_false_for_hard_failures(profile):
+    EMAIL_DELIVERY_METRICS.clear()
+
+    def send_callable():
+        raise ValueError("permanent email template error")
+
+    success = send_transactional_email(
+        send_callable,
+        email_address=profile.user.email,
+        email_type=EmailType.EMAIL_CONFIRMATION,
+        profile=profile,
+        retry_backoff_seconds=(0.0, 0.0),
+    )
+
+    assert success is False
+    assert EmailSent.objects.count() == 0
+    provider = get_email_delivery_provider()
+    assert EMAIL_DELIVERY_METRICS[f"{EmailType.EMAIL_CONFIRMATION}:{provider}:failed"] == 1
+
+
+@pytest.mark.django_db
+def test_confirmation_mail_failures_do_not_bubble_to_signup(user, monkeypatch):
+    def fake_send_confirmation_mail(self, request, emailconfirmation, signup):
+        raise TimeoutError("mailgun unavailable")
+
+    monkeypatch.setattr(
+        DefaultAccountAdapter,
+        "send_confirmation_mail",
+        fake_send_confirmation_mail,
+    )
+
+    adapter = CustomAccountAdapter()
+    emailconfirmation = SimpleNamespace(
+        email_address=SimpleNamespace(user=user, email=user.email)
+    )
+
+    adapter.send_confirmation_mail(None, emailconfirmation, signup=True)
+
+    assert EmailSent.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_feedback_notifications_swallow_email_failures(profile, monkeypatch):
+    def fake_send_mail(*args, **kwargs):
+        raise TimeoutError("smtp timeout")
+
+    monkeypatch.setattr("apps.core.models.send_mail", fake_send_mail)
+
+    feedback = Feedback(
+        profile=profile,
+        feedback="This page helped.",
+        page="/pricing/",
+    )
+    feedback.save()
+
+    assert Feedback.objects.count() == 1
+    assert EmailSent.objects.count() == 0

--- a/{{ cookiecutter.project_slug }}/apps/core/utils.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/utils.py
@@ -1,13 +1,21 @@
-import requests
+import time
+from collections import Counter
+from typing import TYPE_CHECKING, Any, Callable
 
+import requests
+from django.conf import settings
 from django.forms.utils import ErrorList
 
-from apps.core.models import EmailSent, Profile
 from apps.core.choices import EmailType
 
 from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
 
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
+
+if TYPE_CHECKING:
+    from apps.core.models import Profile
+
+EMAIL_DELIVERY_METRICS = Counter()
 
 
 class DivErrorList(ErrorList):
@@ -42,10 +50,53 @@ def ping_healthchecks(ping_id):
 {% endif %}
 
 
-def track_email_sent(email_address: str, email_type: EmailType, profile: Profile = None):
+def get_email_delivery_provider() -> str:
+    backend = getattr(settings, "EMAIL_BACKEND", "")
+    if "mailgun" in backend.lower():
+        return "mailgun"
+    if "smtp" in backend.lower():
+        return "smtp"
+    if "console" in backend.lower():
+        return "console"
+    return backend or "unknown"
+
+
+def get_email_delivery_retry_backoff_seconds() -> tuple[float, ...]:
+    configured = getattr(settings, "EMAIL_DELIVERY_RETRY_BACKOFF_SECONDS", (0.0, 1.0, 3.0))
+    return tuple(float(value) for value in configured)
+
+
+def is_transient_email_error(error: Exception) -> bool:
+    transient_types = (
+        TimeoutError,
+        ConnectionError,
+        requests.Timeout,
+        requests.ConnectionError,
+    )
+    return isinstance(error, transient_types)
+
+
+
+def bump_email_delivery_metric(*, email_type: EmailType, provider: str, outcome: str) -> None:
+    metric_key = f"{email_type}:{provider}:{outcome}"
+    EMAIL_DELIVERY_METRICS[metric_key] += 1
+    logger.info(
+        "email_delivery_metric",
+        email_type=email_type,
+        provider=provider,
+        outcome=outcome,
+        metric_name="email_delivery_total",
+        metric_value=EMAIL_DELIVERY_METRICS[metric_key],
+    )
+
+
+
+def track_email_sent(email_address: str, email_type: EmailType, profile: "Profile" = None):
     """
     Track sent emails by creating EmailSent records.
     """
+    from apps.core.models import EmailSent
+
     try:
         email_sent = EmailSent.objects.create(
             email_address=email_address, email_type=email_type, profile=profile
@@ -67,3 +118,81 @@ def track_email_sent(email_address: str, email_type: EmailType, profile: Profile
             exc_info=True,
         )
         return None
+
+
+
+def send_transactional_email(
+    send_callable: Callable[[], Any],
+    *,
+    email_address: str,
+    email_type: EmailType,
+    profile: "Profile" = None,
+    context: dict[str, Any] | None = None,
+    retry_backoff_seconds: tuple[float, ...] | None = None,
+) -> bool:
+    provider = get_email_delivery_provider()
+    context = context or {}
+    backoff_seconds = retry_backoff_seconds or get_email_delivery_retry_backoff_seconds()
+    max_attempts = max(1, len(backoff_seconds))
+
+    for attempt in range(1, max_attempts + 1):
+        try:
+            send_callable()
+            track_email_sent(
+                email_address=email_address,
+                email_type=email_type,
+                profile=profile,
+            )
+            bump_email_delivery_metric(
+                email_type=email_type,
+                provider=provider,
+                outcome="success",
+            )
+            logger.info(
+                "email_delivery",
+                email_type=email_type,
+                email_address=email_address,
+                provider=provider,
+                outcome="success",
+                attempt=attempt,
+                max_attempts=max_attempts,
+                profile_id=profile.id if profile else None,
+                context=context,
+            )
+            return True
+        except Exception as error:
+            transient = is_transient_email_error(error)
+            should_retry = transient and attempt < max_attempts
+            outcome = "retrying" if should_retry else "failed"
+
+            bump_email_delivery_metric(
+                email_type=email_type,
+                provider=provider,
+                outcome=outcome,
+            )
+            log_method = logger.warning if transient else logger.error
+            log_method(
+                "email_delivery",
+                email_type=email_type,
+                email_address=email_address,
+                provider=provider,
+                outcome=outcome,
+                attempt=attempt,
+                max_attempts=max_attempts,
+                error_class=error.__class__.__name__,
+                error=str(error),
+                transient=transient,
+                profile_id=profile.id if profile else None,
+                context=context,
+                exc_info=not should_retry,
+            )
+
+            if should_retry:
+                sleep_seconds = backoff_seconds[attempt]
+                if sleep_seconds > 0:
+                    time.sleep(sleep_seconds)
+                continue
+
+            return False
+
+    return False

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
@@ -6,7 +6,7 @@ from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.contrib.auth import get_user_model
 
 from apps.core.choices import EmailType
-from apps.core.utils import track_email_sent
+from apps.core.utils import send_transactional_email
 from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
 
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
@@ -36,32 +36,41 @@ class CustomAccountAdapter(DefaultAccountAdapter):
 
         # Track as welcome email during signup, confirmation email on resend
         email_type = EmailType.WELCOME if signup else EmailType.EMAIL_CONFIRMATION
+        email_address = emailconfirmation.email_address.email
+        context = {
+            "flow": "signup" if signup else "confirmation_resend",
+            "user_id": emailconfirmation.email_address.user.id,
+        }
 
         logger.info(
             "[Send Confirmation Mail] Sending email",
             signup=signup,
             email_type=email_type,
             user_id=emailconfirmation.email_address.user.id,
-            email=emailconfirmation.email_address.email,
+            email=email_address,
         )
 
-        try:
-            result = super().send_confirmation_mail(request, emailconfirmation, signup)
-            track_email_sent(
-                email_address=emailconfirmation.email_address.email,
+        success = send_transactional_email(
+            lambda: super(CustomAccountAdapter, self).send_confirmation_mail(
+                request,
+                emailconfirmation,
+                signup,
+            ),
+            email_address=email_address,
+            email_type=email_type,
+            profile=profile,
+            context=context,
+        )
+
+        if not success:
+            logger.warning(
+                "[Send Confirmation Mail] Email send failed after retries",
+                signup=signup,
                 email_type=email_type,
-                profile=profile,
-            )
-            return result
-        except Exception as error:
-            logger.error(
-                "[Send Confirmation Mail] Failed to send email",
-                error=str(error),
-                exc_info=True,
                 user_id=emailconfirmation.email_address.user.id,
-                email=emailconfirmation.email_address.email,
+                email=email_address,
             )
-            raise
+
 
 class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     """

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -340,6 +340,8 @@ else:
     else:
         EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
 
+EMAIL_DELIVERY_RETRY_BACKOFF_SECONDS = (0.0, 1.0, 3.0)
+
 REDIS_HOST = env("REDIS_HOST", default="localhost")
 REDIS_PORT = env("REDIS_PORT", default="6379")
 REDIS_PASSWORD = env("REDIS_PASSWORD", default="")


### PR DESCRIPTION
## Summary
- add a reusable transactional email delivery helper with retry/backoff, structured observability fields, and lightweight counters
- route signup confirmation + feedback notification email sends through the hardened helper so failures do not bubble into user-facing 500s
- add regression coverage for success, transient failure retry, hard failure handling, and no-bubble signup/feedback paths

## Verification
- `uv run --group test pytest`

## Runbook note
If transactional email delivery fails in production, inspect structured `email_delivery` / `email_delivery_metric` logs first. Filter by `email_type`, `provider`, `outcome`, and `error_class` to distinguish transient transport issues (retries exhausted) from hard template/configuration failures. The retry cadence is controlled by `EMAIL_DELIVERY_RETRY_BACKOFF_SECONDS` in settings.

## Context
- Paperclip issue: LVT-55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Email delivery now automatically retries transient failures with configurable backoff.
  * Added structured observability metrics for email delivery monitoring.

* **Bug Fixes**
  * Confirmation and feedback email failures no longer propagate to user-facing HTTP 500 responses.

* **Tests**
  * Added comprehensive test coverage for email delivery behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->