### PR TITLE
fix: make fresh local boot wait for frontend assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Fresh local boot now uses Node 24 for the frontend dev container, waits for the frontend manifest healthcheck before starting the backend, and keeps Tailwind imports ordered so default builds avoid the PostCSS import warning.
 - Added a regression test that scans generated projects for maintainer-specific hard-coded literals (e.g., `rasulkireev.com`, `Rasul`) to keep template output generic and reusable.
 - Docker deployment images no longer fail to build when `uv.lock` is missing (the default in freshly-generated projects)
 - Healthcheck endpoint now returns boolean `healthy` (instead of string statuses) for simpler monitoring integrations

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -215,6 +215,18 @@ def test_use_s3_toggles_minio_in_docker_compose(tmp_path: Path) -> None:
     assert "minio" not in disabled_compose.lower()
 
 
+def test_local_compose_waits_for_frontend_ready_and_uses_supported_node(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path)
+
+    compose = _read_text(project_dir / "docker-compose-local.yml")
+    styles = _read_text(project_dir / "frontend" / "src" / "styles" / "index.css")
+
+    assert "image: node:24" in compose
+    assert 'condition: service_healthy' in compose
+    assert 'test -f /app/frontend/build/manifest.json' in compose
+    assert styles.index('@import "tailwindcss";') < styles.index('@import "./pygments.css";') < styles.index('@config "../../../tailwind.config.js";')
+
+
 def test_use_posthog_toggles_posthog_snippet(tmp_path: Path) -> None:
     enabled = _generate(tmp_path, use_posthog="y")
     disabled = _generate(tmp_path, use_posthog="n")

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -144,6 +144,7 @@ You'd still need to make sure .env has correct values.
    - Important: run this **without specifying app names** so Django detects changes across **all apps**.
    - Do this before feature work and before first local run.
 4. Run `make serve`
+   - The frontend dev container now uses Node 24 and the backend waits for `frontend/build/manifest.json` before booting, so the first page load should not race the asset pipeline.
 5. Run `make restart-worker` just in case, it sometimes has troubles connecting to REDIS on first deployment.
 
 ### CI (optional)

--- a/{{ cookiecutter.project_slug }}/docker-compose-local.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose-local.yml
@@ -41,7 +41,7 @@ services:
       redis:
         condition: service_started
       frontend:
-        condition: service_started
+        condition: service_healthy
     env_file:
       - .env
 
@@ -62,13 +62,19 @@ services:
       - .env
 
   frontend:
-    image: node:18
+    image: node:24
     working_dir: /app
     command: sh -c "npm install && npm run start"
     volumes:
       - .:/app
     ports:
       - "9091:9091"
+    healthcheck:
+      test: ["CMD-SHELL", "test -f /app/frontend/build/manifest.json"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
 
   mailhog:
     image: mailhog/mailhog

--- a/{{ cookiecutter.project_slug }}/frontend/src/styles/index.css
+++ b/{{ cookiecutter.project_slug }}/frontend/src/styles/index.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
+@import "./pygments.css";
 @config "../../../tailwind.config.js";
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
-@import "./pygments.css";


### PR DESCRIPTION
## Summary
- move local frontend dev container to Node 24
- gate backend startup on a frontend manifest healthcheck instead of plain container start
- reorder Tailwind/Pygments imports and cover the regression in template tests

## Verification
- `uv run --group test pytest tests/test_cookiecutter_template.py -q`
- `uv run --group test python - <<'PY' ... cookiecutter(...) ... PY` to generate a fresh project with the lean config from LVT-57
- `NODE_ENV=development npm install && timeout 45s npm run start` inside the freshly generated project
  - webpack compiled successfully
  - `frontend/build/manifest.json` was written on startup
  - no `postcss-import: @import must precede all other statements` warning appeared

## Why
Fresh local boots were still brittle after the Tailwind v4 upgrade: the local compose file pinned Node 18, the backend could race ahead before frontend assets existed, and the default stylesheet import order still triggered a PostCSS warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Backend startup now automatically waits for frontend readiness, eliminating race conditions during local development boot.

* **Improvements**
  * Updated Node.js version to 24 for enhanced performance and tooling compatibility.
  * Fixed CSS import ordering to prevent PostCSS build warnings.

* **Documentation**
  * Updated local development setup instructions to clarify startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->