### PR TITLE
Fix no-Stripe template leftovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ## [Unreleased]
 
 - Fix pricing page dark mode styles.
+- Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
 - Passkey authentication (WebAuthn) in generated projects: sign in + sign up flows via `django-allauth` MFA.
 - Ability for users to permanently delete their account (Danger Zone modal in settings)

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -50,6 +50,11 @@ def remove_stripe_files():
         stripe_tests_path.unlink()
         print("Removed Stripe webhook tests")
 
+    pricing_template_path = Path("frontend/templates/pages/pricing.html")
+    if pricing_template_path.exists():
+        pricing_template_path.unlink()
+        print("Removed pricing template")
+
 
 def remove_ci_workflow():
     """Remove CI workflow if use_ci is 'n'."""

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -159,11 +159,40 @@ def test_generate_without_stripe_removes_stripe_files(tmp_path: Path) -> None:
 
     assert not (project_dir / "apps" / "core" / "stripe_webhooks.py").exists()
     assert not (project_dir / "apps" / "core" / "tests" / "test_stripe_webhooks.py").exists()
+    assert not (project_dir / "frontend" / "templates" / "pages" / "pricing.html").exists()
 
     # pricing route should be removed when stripe is off
     urls_py = project_dir / "apps" / "pages" / "urls.py"
     assert urls_py.exists()
     _assert_not_contains(urls_py, "pricing")
+
+    # no subscription-only helpers or API fields should leak into the generated project
+    _assert_not_contains(project_dir / "apps" / "core" / "models.py", "has_active_subscription")
+    _assert_not_contains(project_dir / "apps" / "api" / "schemas.py", "has_pro_subscription")
+    _assert_not_contains(project_dir / "apps" / "api" / "views.py", "has_pro_subscription")
+
+    choices_py = project_dir / "apps" / "core" / "choices.py"
+    _assert_not_contains(choices_py, "TRIAL_STARTED")
+    _assert_not_contains(choices_py, "TRIAL_ENDED")
+    _assert_not_contains(choices_py, "SUBSCRIBED")
+    _assert_not_contains(choices_py, "CANCELLED")
+    _assert_not_contains(choices_py, "CHURNED")
+
+    landing_page = project_dir / "frontend" / "templates" / "pages" / "landing-page.html"
+    _assert_not_contains(landing_page, "How does pricing work?")
+    _assert_not_contains(landing_page, "premium plans")
+
+    privacy_policy = project_dir / "frontend" / "templates" / "pages" / "privacy-policy.html"
+    _assert_not_contains(privacy_policy, "processed securely through Stripe")
+    _assert_not_contains(privacy_policy, "Process transactions and send related information")
+    _assert_not_contains(privacy_policy, "Secure payment processing through PCI-compliant providers (Stripe)")
+    _assert_not_contains(privacy_policy, "Stripe (payment processing)")
+    _assert_not_contains(privacy_policy, "Payment records: Retained for 7 years for tax and accounting purposes")
+
+    terms_of_service = project_dir / "frontend" / "templates" / "pages" / "terms-of-service.html"
+    _assert_not_contains(terms_of_service, "Paid subscriptions are billed in advance on a recurring basis.")
+    _assert_not_contains(terms_of_service, "subscription tier")
+    _assert_contains(terms_of_service, "The default starter does not include recurring paid subscriptions.")
 
 
 def test_generate_with_stripe_keeps_stripe_files_and_pricing(tmp_path: Path) -> None:
@@ -171,9 +200,12 @@ def test_generate_with_stripe_keeps_stripe_files_and_pricing(tmp_path: Path) -> 
 
     assert (project_dir / "apps" / "core" / "stripe_webhooks.py").exists()
     assert (project_dir / "apps" / "core" / "tests" / "test_stripe_webhooks.py").exists()
+    assert (project_dir / "frontend" / "templates" / "pages" / "pricing.html").exists()
     urls_py = project_dir / "apps" / "pages" / "urls.py"
     assert urls_py.exists()
     _assert_contains(urls_py, "pricing")
+    _assert_contains(project_dir / "apps" / "api" / "schemas.py", "has_pro_subscription")
+    _assert_contains(project_dir / "apps" / "core" / "models.py", "has_active_subscription")
 
 
 def test_generate_without_ci_removes_ci_workflow(tmp_path: Path) -> None:

--- a/{{ cookiecutter.project_slug }}/apps/api/schemas.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/schemas.py
@@ -62,7 +62,9 @@ class BlogPostDetailOut(Schema):
 
 
 class ProfileSettingsOut(Schema):
+    {% if cookiecutter.use_stripe == 'y' %}
     has_pro_subscription: bool
+    {% endif %}
 
 
 class UserSettingsOut(Schema):

--- a/{{ cookiecutter.project_slug }}/apps/api/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/views.py
@@ -318,7 +318,9 @@ def user_settings(request: HttpRequest):
     profile = request.auth
     try:
         profile_data = {
+            {% if cookiecutter.use_stripe == 'y' %}
             "has_pro_subscription": profile.has_active_subscription,
+            {% endif %}
         }
         data = {"profile": profile_data}
 

--- a/{{ cookiecutter.project_slug }}/apps/core/choices.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/choices.py
@@ -4,11 +4,13 @@ class ProfileStates(models.TextChoices):
     STRANGER = "stranger"
     SIGNED_UP = "signed_up"
     FREE = "free" # This can be used for Freemium apps, and will be set when core action is completed
+    {% if cookiecutter.use_stripe == 'y' %}
     TRIAL_STARTED = "trial_started" # This can be used in apps with Trials
     TRIAL_ENDED = "trial_ended"
     SUBSCRIBED = "subscribed"
     CANCELLED = "cancelled" # when user cancels their subscription, but still have access
     CHURNED = "churned"  # when user lost access to paid features
+    {% endif %}
     ACCOUNT_DELETED = "account_deleted"
 
 

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/landing-page.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/landing-page.html
@@ -48,10 +48,11 @@
           </dt>
           <el-disclosure id="faq-0" class="[&:not([hidden])]:contents">
             <dd class="pr-12 mt-2">
-              <p class="text-gray-600 text-base/7 dark:text-gray-400">Our platform includes everything you need to get started quickly. All plans include core features, with premium plans offering advanced functionality and priority support.</p>
+              <p class="text-gray-600 text-base/7 dark:text-gray-400">Our platform includes the core workflows you need to get started quickly, with room to customize the experience for your own product.</p>
             </dd>
           </el-disclosure>
         </div>
+        {% if cookiecutter.use_stripe == 'y' %}
         <div class="py-6 first:pt-0 last:pb-0">
           <dt>
             <button type="button" command="--toggle" commandfor="faq-1" class="flex justify-between items-start w-full text-left text-gray-900 dark:text-white">
@@ -72,6 +73,7 @@
             </dd>
           </el-disclosure>
         </div>
+        {% endif %}
       </dl>
     </div>
   </div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/privacy-policy.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/privacy-policy.html
@@ -43,7 +43,9 @@
       <li>Name and email address</li>
       <li>Account credentials</li>
       <li>Project information and content</li>
+      {% if cookiecutter.use_stripe == 'y' %}
       <li>Payment information (processed securely through Stripe)</li>
+      {% endif %}
       <li>Communication preferences</li>
     </ul>
 
@@ -51,7 +53,9 @@
     <p>We use the information we collect to: </p>
     <ul>
       <li>Provide, maintain, and improve our services</li>
+      {% if cookiecutter.use_stripe == 'y' %}
       <li>Process transactions and send related information</li>
+      {% endif %}
       <li>Send technical notices, updates, and support messages</li>
       <li>Respond to your comments and questions</li>
       <li>Monitor and analyze usage and trends</li>
@@ -81,7 +85,9 @@
       <li>Encryption of sensitive data at rest</li>
       <li>Regular security audits and updates</li>
       <li>Access controls and authentication requirements</li>
+      {% if cookiecutter.use_stripe == 'y' %}
       <li>Secure payment processing through PCI-compliant providers (Stripe)</li>
+      {% endif %}
     </ul>
     <p>
       However, no method of transmission over the internet is 100% secure. While we
@@ -99,7 +105,9 @@
       Third-party services that may set cookies include:
     </p>
     <ul>
+      {% if cookiecutter.use_stripe == 'y' %}
       <li>Stripe (payment processing)</li>
+      {% endif %}
       <li>Google Analytics (usage analytics)</li>
       <li>[Any other third-party services you use]</li>
     </ul>
@@ -180,7 +188,9 @@
     <ul>
       <li>Account information: Retained while your account is active</li>
       <li>Content and projects: Retained until you delete them or close your account</li>
+      {% if cookiecutter.use_stripe == 'y' %}
       <li>Payment records: Retained for 7 years for tax and accounting purposes</li>
+      {% endif %}
       <li>Marketing data: Retained until you unsubscribe or request deletion</li>
     </ul>
     <p>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/terms-of-service.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/terms-of-service.html
@@ -83,12 +83,21 @@
       content is plagiarism-free, factually accurate, or suitable for your specific use case.
     </p>
 
+    {% if cookiecutter.use_stripe == 'y' %}
     <h2>7. Payment Terms</h2>
     <p>
       Paid subscriptions are billed in advance on a recurring basis. All fees are
       non-refundable unless otherwise stated. We reserve the right to change our pricing
       with 30 days' notice to existing subscribers.
     </p>
+    {% else %}
+    <h2>7. Service Access</h2>
+    <p>
+      The default starter does not include recurring paid subscriptions. If you later add
+      paid plans or commercial features, you should update these terms to describe billing,
+      refunds, and any product-specific limits.
+    </p>
+    {% endif %}
 
     <h2>8. Service Availability</h2>
     <p>
@@ -166,8 +175,9 @@
 
     <h2>18. Service Limits</h2>
     <p>
-      Your use of the Service is subject to rate limits and usage quotas based on your
-      subscription tier. Excessive use may result in temporary service restrictions.
+      Your use of the Service may be subject to reasonable rate limits and usage quotas
+      to protect reliability for all users. Excessive use may result in temporary service
+      restrictions.
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- remove subscription-only states, API fields, and pricing template leftovers from `use_stripe = n` generation
- conditionalize landing/legal copy so non-Stripe apps stop shipping paid-product wording by default
- deepen cookiecutter regression coverage for both no-Stripe and Stripe-enabled variants

## Audit / remove / conditionalize checklist
- [x] `apps/core/choices.py` — remove Stripe-only profile states from non-Stripe generation
- [x] `apps/api/views.py` + `apps/api/schemas.py` — remove `has_pro_subscription` from the non-Stripe API contract
- [x] `frontend/templates/pages/landing-page.html` — remove pricing FAQ / premium-plan copy when Stripe is disabled
- [x] `frontend/templates/pages/privacy-policy.html` — conditionalize payment-processing / Stripe / payment-retention copy
- [x] `frontend/templates/pages/terms-of-service.html` — replace paid-subscription wording with neutral non-Stripe service-access text
- [x] post-gen cleanup — delete generated `frontend/templates/pages/pricing.html` when Stripe is disabled
- [x] tests — add deeper `use_stripe = n` assertions and preserve Stripe-enabled assertions

## Verification
- `uv run --group test pytest tests/test_cookiecutter_template.py`

## Issue
- LVT-58
