### PR TITLE
Add admin blog CRUD API to generated projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Generated projects with `generate_blog = y` now include a superuser-only admin blog API for creating, listing, reading, updating, patching, deleting, reviewing, and publishing blog posts.
 - Passkey authentication (WebAuthn) in generated projects: sign in + sign up flows via `django-allauth` MFA.
 - Ability for users to permanently delete their account (Danger Zone modal in settings)
 - Dark/light mode toggle in navbar (generated projects)
@@ -56,6 +57,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Generated projects with `use_stripe = n` now keep `ProfileSettingsOut` syntactically valid when importing API schemas.
 - Fresh local boot now uses Node 24 for the frontend dev container, waits for the frontend manifest healthcheck before starting the backend, and keeps Tailwind imports ordered so default builds avoid the PostCSS import warning.
 - DEBUG-mode settings now allow tunnel-based local development (localhost, backend, ngrok/trycloudflare/loca.lt CSRF origins) while keeping non-DEBUG host/CSRF restrictions scoped to `SITE_URL`.
 - Added a regression test that scans generated projects for maintainer-specific hard-coded literals (e.g., `rasulkireev.com`, `Rasul`) to keep template output generic and reusable.

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -157,6 +157,43 @@ def test_generate_without_blog_removes_blog_app_and_templates(tmp_path: Path) ->
     assert not (project_dir / "frontend" / "templates" / "blog").exists()
 
 
+def test_generate_with_blog_includes_admin_blog_crud_api(tmp_path):
+    project_dir = _generate(tmp_path, generate_blog="y")
+
+    api_views = project_dir / "apps" / "api" / "views.py"
+    api_schemas = project_dir / "apps" / "api" / "schemas.py"
+    api_tests = project_dir / "apps" / "api" / "tests.py"
+
+    for endpoint in [
+        '"/blog-posts/submit"',
+        '"/internal/blog-posts"',
+        '"/internal/blog-posts/{blog_post_id}"',
+        '"/internal/blog-posts/{blog_post_id}/review"',
+        '"/internal/blog-posts/{blog_post_id}/publish"',
+    ]:
+        _assert_contains(api_views, endpoint)
+
+    for method in ["@api.post", "@api.get", "@api.put", "@api.patch", "@api.delete"]:
+        _assert_contains(api_views, method)
+
+    _assert_contains(api_views, "auth=[superuser_api_auth]")
+    _assert_contains(api_schemas, "class BlogPostIn")
+    _assert_contains(api_schemas, "class BlogPostUpdateIn")
+    _assert_contains(api_tests, "class BlogPostApiTests")
+    _assert_contains(api_tests, "test_delete_internal_blog_post_deletes_existing_post")
+
+
+def test_generate_without_blog_removes_admin_blog_crud_api(tmp_path):
+    project_dir = _generate(tmp_path, generate_blog="n")
+
+    api_views = project_dir / "apps" / "api" / "views.py"
+    api_schemas = project_dir / "apps" / "api" / "schemas.py"
+
+    _assert_not_contains(api_views, "BlogPost")
+    _assert_not_contains(api_views, "/internal/blog-posts")
+    _assert_not_contains(api_schemas, "BlogPostIn")
+
+
 def test_generate_without_docs_removes_docs_app_and_templates(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path, generate_docs="n")
 

--- a/{{ cookiecutter.project_slug }}/CHANGELOG.md
+++ b/{{ cookiecutter.project_slug }}/CHANGELOG.md
@@ -15,4 +15,6 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 
 
 ## [Unreleased]
-...
+
+### Added
+- Superuser-only admin blog API for creating, listing, reading, updating, patching, deleting, reviewing, and publishing blog posts when the blog app is generated.

--- a/{{ cookiecutter.project_slug }}/apps/api/schemas.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/schemas.py
@@ -64,6 +64,8 @@ class BlogPostDetailOut(Schema):
 class ProfileSettingsOut(Schema):
     {% if cookiecutter.use_stripe == 'y' %}
     has_pro_subscription: bool
+    {% else %}
+    pass
     {% endif %}
 
 

--- a/{{ cookiecutter.project_slug }}/apps/api/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/tests.py
@@ -1,24 +1,68 @@
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase
 from django.http import HttpRequest
 
 {% if cookiecutter.generate_blog == 'y' %}
 from apps.blog.choices import BlogPostStatus
 from apps.api.views import (
+    submit_blog_post,
     list_internal_blog_posts,
     get_internal_blog_post,
+    update_internal_blog_post,
+    patch_internal_blog_post,
+    delete_internal_blog_post,
+    review_internal_blog_post,
     publish_internal_blog_post,
 )
 
 
-class BlogPostApiTests(TestCase):
+class BlogPostApiTests(SimpleTestCase):
     @staticmethod
     def _request() -> HttpRequest:
         request = HttpRequest()
         request.auth = SimpleNamespace(user=SimpleNamespace(is_superuser=True))
         return request
+
+    @staticmethod
+    def _post_data(**overrides):
+        data = {
+            "title": "Hello",
+            "description": "Desc",
+            "slug": "hello",
+            "tags": "django",
+            "content": "Body",
+            "status": BlogPostStatus.DRAFT,
+        }
+        data.update(overrides)
+        return SimpleNamespace(**data)
+
+    def test_submit_blog_post_requires_superuser(self):
+        request = HttpRequest()
+        request.auth = SimpleNamespace(user=SimpleNamespace(is_superuser=False))
+
+        status, payload = submit_blog_post(request, self._post_data())
+
+        assert status == 403
+        assert payload["message"] == "Forbidden: superuser access required."
+
+    def test_submit_blog_post_creates_draft_post(self):
+        request = self._request()
+        data = self._post_data()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            response = submit_blog_post(request, data)
+
+        assert response.status == "success"
+        objects.create.assert_called_once_with(
+            title="Hello",
+            description="Desc",
+            slug="hello",
+            tags="django",
+            content="Body",
+            status=BlogPostStatus.DRAFT,
+        )
 
     def test_list_internal_blog_posts_returns_serialized_items(self):
         request = self._request()
@@ -65,10 +109,79 @@ class BlogPostApiTests(TestCase):
         assert response["status"] == "success"
         assert post.status == BlogPostStatus.PUBLISHED
         post.save.assert_called_once()
+
+    def test_update_internal_blog_post_replaces_all_editable_fields(self):
+        request = self._request()
+        post = Mock()
+        data = self._post_data(title="Updated", status=BlogPostStatus.PUBLISHED)
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.get.return_value = post
+            response = update_internal_blog_post(request, blog_post_id=12, data=data)
+
+        assert response["status"] == "success"
+        assert post.title == "Updated"
+        assert post.status == BlogPostStatus.PUBLISHED
+        post.save.assert_called_once_with(
+            update_fields=["title", "description", "slug", "tags", "content", "status", "updated_at"]
+        )
+
+    def test_patch_internal_blog_post_updates_only_supplied_fields(self):
+        request = self._request()
+        post = Mock()
+        data = SimpleNamespace(
+            title=None,
+            description="New desc",
+            slug=None,
+            tags=None,
+            content=None,
+            status=BlogPostStatus.PUBLISHED,
+        )
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.get.return_value = post
+            response = patch_internal_blog_post(request, blog_post_id=12, data=data)
+
+        assert response["status"] == "success"
+        assert post.description == "New desc"
+        assert post.status == BlogPostStatus.PUBLISHED
+        post.save.assert_called_once_with(update_fields=["description", "status", "updated_at"])
+
+    def test_delete_internal_blog_post_deletes_existing_post(self):
+        request = self._request()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.filter.return_value.delete.return_value = (1, {})
+            response = delete_internal_blog_post(request, blog_post_id=12)
+
+        assert response["status"] == "success"
+        objects.filter.assert_called_once_with(id=12)
+
+    def test_delete_internal_blog_post_returns_404_when_missing(self):
+        request = self._request()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.filter.return_value.delete.return_value = (0, {})
+            status, payload = delete_internal_blog_post(request, blog_post_id=404)
+
+        assert status == 404
+        assert payload["message"] == "Blog post not found."
+
+    def test_review_internal_blog_post_moves_post_to_draft(self):
+        request = self._request()
+        post = Mock()
+
+        with patch("apps.api.views.BlogPost.objects") as objects:
+            objects.get.return_value = post
+            response = review_internal_blog_post(request, blog_post_id=12)
+
+        assert response["status"] == "success"
+        assert post.status == BlogPostStatus.DRAFT
+        post.save.assert_called_once_with(update_fields=["status", "updated_at"])
 {% else %}
 
 
-class PlaceholderApiTests(TestCase):
+class PlaceholderApiTests(SimpleTestCase):
     def test_placeholder(self):
         assert True
 {% endif %}

--- a/{{ cookiecutter.project_slug }}/apps/api/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/tests.py
@@ -108,7 +108,7 @@ class BlogPostApiTests(SimpleTestCase):
 
         assert response["status"] == "success"
         assert post.status == BlogPostStatus.PUBLISHED
-        post.save.assert_called_once()
+        post.save.assert_called_once_with(update_fields=["status", "updated_at"])
 
     def test_update_internal_blog_post_replaces_all_editable_fields(self):
         request = self._request()

--- a/{{ cookiecutter.project_slug }}/apps/api/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/views.py
@@ -132,7 +132,7 @@ def _serialize_blog_post(blog_post: BlogPost) -> BlogPostItemOut:
 
 @api.post(
     "/blog-posts/submit",
-    response=BlogPostOut,
+    response={200: BlogPostOut, 403: BlogPostOut},
     auth=[superuser_api_auth],
     include_in_schema=False,
     tags=["admin"],

--- a/{{ cookiecutter.project_slug }}/apps/api/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/views.py
@@ -141,7 +141,7 @@ def submit_blog_post(request: HttpRequest, data: BlogPostIn):
     profile = request.auth
 
     if not profile or not getattr(profile.user, "is_superuser", False):
-        return BlogPostOut(status="error", message="Forbidden: superuser access required."), 403
+        return 403, {"status": "error", "message": "Forbidden: superuser access required."}
 
     try:
         BlogPost.objects.create(


### PR DESCRIPTION
## Summary
- Keep the generated blog API importable when Stripe is disabled by adding a valid empty `ProfileSettingsOut` schema.
- Expand generated API tests to cover superuser-only blog create, list, read, update, patch, delete, review, and publish operations.
- Add template-level regression checks so `generate_blog = y` includes the admin blog CRUD API and `generate_blog = n` removes it.
- Update root and generated-project changelogs.

## Verification
- `uv run --group test pytest -q`
- Generated a fresh project with `generate_blog=y`, `use_stripe=n`; ran `uv run pytest apps/api/tests.py -q` with required env vars: 10 passed.

## Notes
Djass and TuxSEO only had the create endpoint pattern. The starter already had the fuller CRUD implementation on current `main`, so this PR locks it in with tests and fixes the schema import issue that the generated API test exposed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Admin-only blog API with complete CRUD operations, review, and publish functionality when blog feature is enabled

* **Bug Fixes**
  * Fixed schema validation syntax for projects without Stripe integration
  * Corrected API error response format for unauthorized blog endpoint access

* **Tests**
  * Added comprehensive test coverage for blog feature generation and API endpoint validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->