### PR TITLE
feat: add generated signup pause flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Generated projects now include an `ALLOW_SIGNUPS` environment flag (default `True`) to pause new email/social registrations while keeping existing user logins available.
 - Generated projects with `generate_blog = y` now include a superuser-only admin blog API for creating, listing, reading, updating, patching, deleting, reviewing, and publishing blog posts.
 - Passkey authentication (WebAuthn) in generated projects: sign in + sign up flows via `django-allauth` MFA.
 - Ability for users to permanently delete their account (Danger Zone modal in settings)

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -131,6 +131,21 @@ def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
     _assert_contains(settings_py, "MFA_PASSKEY_LOGIN_ENABLED = True")
     _assert_contains(settings_py, "MFA_PASSKEY_SIGNUP_ENABLED = True")
     _assert_contains(settings_py, "MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG")
+    _assert_contains(settings_py, 'ALLOW_SIGNUPS = env.bool("ALLOW_SIGNUPS", default=True)')
+
+    _assert_contains(project_dir / ".env.example", "ALLOW_SIGNUPS=True")
+    _assert_contains(
+        project_dir / "apps" / "docs" / "content" / "deployment" / "environment-variables.md",
+        "**ALLOW_SIGNUPS**",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "signup_closed.html",
+        "Signups paused",
+    )
+    _assert_contains(
+        project_dir / "apps" / "core" / "tests" / "test_signup_gating.py",
+        "test_account_signup_adapter_can_pause_new_signups",
+    )
 
     _assert_contains(urls_py, "accounts/signup/passkey/")
     _assert_contains(urls_py, "account_signup_by_passkey")

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -16,6 +16,9 @@ SECRET_KEY="super-secret-key"
 
 SITE_URL=http://localhost:8000
 
+# Set to False to pause new account creation while keeping existing logins working.
+ALLOW_SIGNUPS=True
+
 POSTGRES_HOST=db
 POSTGRES_DB={{ cookiecutter.project_slug }}
 POSTGRES_USER={{ cookiecutter.project_slug }}

--- a/{{ cookiecutter.project_slug }}/CHANGELOG.md
+++ b/{{ cookiecutter.project_slug }}/CHANGELOG.md
@@ -17,4 +17,5 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 ## [Unreleased]
 
 ### Added
+- `ALLOW_SIGNUPS` environment flag (default `True`) to pause new email/social registrations while keeping existing user logins available.
 - Superuser-only admin blog API for creating, listing, reading, updating, patching, deleting, reviewing, and publishing blog posts when the blog app is generated.

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_signup_gating.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_signup_gating.py
@@ -1,0 +1,64 @@
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.test import RequestFactory, override_settings
+from django.urls import path
+from django.utils.module_loading import import_string
+from django.views.generic import TemplateView
+
+urlpatterns = [
+    path("", TemplateView.as_view(), name="landing"),
+    path("accounts/login/", TemplateView.as_view(), name="account_login"),
+    path("accounts/signup/", TemplateView.as_view(), name="account_signup"),
+    path("app/", TemplateView.as_view(), name="home"),
+    path("blog/", TemplateView.as_view(), name="blog_posts"),
+    path("docs/", TemplateView.as_view(), name="docs_home"),
+    path("privacy/", TemplateView.as_view(), name="privacy_policy"),
+    path("terms/", TemplateView.as_view(), name="terms_of_service"),
+]
+
+
+def _account_adapter():
+    return import_string(settings.ACCOUNT_ADAPTER)()
+
+
+def _social_account_adapter():
+    return import_string(settings.SOCIALACCOUNT_ADAPTER)()
+
+
+@override_settings(ALLOW_SIGNUPS=True)
+def test_account_signup_adapter_defaults_open_for_signups():
+    request = RequestFactory().get("/accounts/signup/")
+
+    assert _account_adapter().is_open_for_signup(request) is True
+
+
+@override_settings(ALLOW_SIGNUPS=False)
+def test_account_signup_adapter_can_pause_new_signups():
+    request = RequestFactory().get("/accounts/signup/")
+
+    assert _account_adapter().is_open_for_signup(request) is False
+
+
+@override_settings(ALLOW_SIGNUPS=True)
+def test_social_signup_adapter_defaults_open_for_signups():
+    request = RequestFactory().get("/accounts/github/login/callback/")
+
+    assert _social_account_adapter().is_open_for_signup(request, sociallogin=None) is True
+
+
+@override_settings(ALLOW_SIGNUPS=False)
+def test_social_signup_adapter_uses_same_signup_gate():
+    request = RequestFactory().get("/accounts/github/login/callback/")
+
+    assert _social_account_adapter().is_open_for_signup(request, sociallogin=None) is False
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_signup_closed_template_tells_existing_users_to_log_in():
+    content = render_to_string("account/signup_closed.html")
+
+    assert "Signups paused" in content
+    assert "Existing users can continue using the product as usual" in content
+    assert 'href="/accounts/login/"' in content
+    assert 'name="email"' not in content
+    assert 'name="password1"' not in content

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_signup_gating.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_signup_gating.py
@@ -39,6 +39,13 @@ def test_account_signup_adapter_can_pause_new_signups():
     assert _account_adapter().is_open_for_signup(request) is False
 
 
+def test_account_signup_adapter_defaults_open_when_setting_is_absent(monkeypatch):
+    request = RequestFactory().get("/accounts/signup/")
+    monkeypatch.delattr(settings, "ALLOW_SIGNUPS", raising=False)
+
+    assert _account_adapter().is_open_for_signup(request) is True
+
+
 @override_settings(ALLOW_SIGNUPS=True)
 def test_social_signup_adapter_defaults_open_for_signups():
     request = RequestFactory().get("/accounts/github/login/callback/")
@@ -51,6 +58,13 @@ def test_social_signup_adapter_uses_same_signup_gate():
     request = RequestFactory().get("/accounts/github/login/callback/")
 
     assert _social_account_adapter().is_open_for_signup(request, sociallogin=None) is False
+
+
+def test_social_signup_adapter_defaults_open_when_setting_is_absent(monkeypatch):
+    request = RequestFactory().get("/accounts/github/login/callback/")
+    monkeypatch.delattr(settings, "ALLOW_SIGNUPS", raising=False)
+
+    assert _social_account_adapter().is_open_for_signup(request, sociallogin=None) is True
 
 
 @override_settings(ROOT_URLCONF=__name__)

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
@@ -34,6 +34,11 @@ These variables are essential for {{ cookiecutter.project_name }} to function:
 - Example: `https://yourdomain.com`
 - Used for generating absolute URLs in emails and notifications
 
+**ALLOW_SIGNUPS**
+- Set to `False` to pause new account creation
+- Defaults to `True`
+- Existing users can still log in while signups are paused
+
 **ALLOWED_HOSTS**
 - Comma-separated list of domains that can access your application
 - Example: `yourdomain.com,www.yourdomain.com`

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/signup_closed.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/signup_closed.html
@@ -1,0 +1,19 @@
+{{ '{% extends "base_landing.html" %}' }}
+
+{{ "{% block content %}" }}
+<main class="flex justify-center items-center px-4 py-16 my-4 sm:px-6 lg:px-8">
+  <section class="space-y-6 w-full max-w-md text-center" aria-labelledby="signup-closed-heading">
+    <div>
+      <p class="text-sm font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">Signups paused</p>
+      <h1 id="signup-closed-heading" class="mt-3 text-3xl font-extrabold text-gray-900 dark:text-gray-100">{{ cookiecutter.project_name }} is not accepting new accounts right now.</h1>
+      <p class="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        Existing users can continue using the product as usual. New account creation is paused for now.
+      </p>
+    </div>
+    <a href="{% raw %}{% url 'account_login' %}{%- endraw %}"
+       class="inline-flex justify-center px-5 py-3 text-sm font-semibold text-white bg-{{ cookiecutter.project_main_color }}-600 rounded-md hover:bg-{{ cookiecutter.project_main_color }}-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{ cookiecutter.project_main_color }}-500 dark:focus:ring-offset-gray-950">
+      Log in to your account
+    </a>
+  </section>
+</main>
+{{ '{% endblock content %}' }}

--- a/{{ cookiecutter.project_slug }}/render.yaml
+++ b/{{ cookiecutter.project_slug }}/render.yaml
@@ -125,6 +125,10 @@ envVarGroups:
       - key: SITE_URL
         value: $RENDER_EXTERNAL_URL
 
+      # Set to False to pause new account creation while keeping existing logins working.
+      - key: ALLOW_SIGNUPS
+        value: "True"
+
       {% if cookiecutter.use_s3 == 'y' %}
       # Optional. If not specified, local FileSystemStorage is used for media files.
       - key: AWS_S3_ENDPOINT_URL

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
@@ -3,6 +3,7 @@ import uuid
 
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
+from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from apps.core.choices import EmailType
@@ -18,6 +19,10 @@ class CustomAccountAdapter(DefaultAccountAdapter):
     """
     Custom adapter to track email confirmations and welcome emails.
     """
+
+    def is_open_for_signup(self, request):
+        """Allow operators to pause new registrations without affecting existing users."""
+        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request)
 
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         """
@@ -77,6 +82,10 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
     Custom adapter to automatically generate usernames from email addresses
     during social authentication signup, bypassing the username selection page.
     """
+
+    def is_open_for_signup(self, request, sociallogin):
+        """Mirror email signup gating for social-account auto-signups."""
+        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request, sociallogin)
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/adapters.py
@@ -22,7 +22,7 @@ class CustomAccountAdapter(DefaultAccountAdapter):
 
     def is_open_for_signup(self, request):
         """Allow operators to pause new registrations without affecting existing users."""
-        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request)
+        return getattr(settings, "ALLOW_SIGNUPS", True) and super().is_open_for_signup(request)
 
     def send_confirmation_mail(self, request, emailconfirmation, signup):
         """
@@ -85,7 +85,10 @@ class CustomSocialAccountAdapter(DefaultSocialAccountAdapter):
 
     def is_open_for_signup(self, request, sociallogin):
         """Mirror email signup gating for social-account auto-signups."""
-        return settings.ALLOW_SIGNUPS and super().is_open_for_signup(request, sociallogin)
+        return getattr(settings, "ALLOW_SIGNUPS", True) and super().is_open_for_signup(
+            request,
+            sociallogin,
+        )
 
     def populate_user(self, request, sociallogin, data):
         """

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -299,6 +299,7 @@ ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True
+ALLOW_SIGNUPS = env.bool("ALLOW_SIGNUPS", default=True)
 ACCOUNT_FORMS = {
     "signup": "apps.core.forms.CustomSignUpForm",
     "login": "apps.core.forms.CustomLoginForm",


### PR DESCRIPTION
## Summary
- add generated `ALLOW_SIGNUPS` env flag (defaults to `True`) for pausing new registrations
- gate generated allauth email/password and social-account signups through the same setting while preserving upstream allauth guards
- add generated `account/signup_closed.html` closed-state page
- document the flag in `.env.example`, Render config, generated deployment docs, and changelogs
- add generated regression tests plus cookiecutter template assertions

## Verification
- `uv run --group test pytest`
- `uv run --with ruff ruff check tests/test_cookiecutter_template.py`
- generated-project smoke: `uv run pytest apps/core/tests/test_signup_gating.py -q` (5 passed)
- generated-project lint: `uv run ruff check test_project/adapters.py apps/core/tests/test_signup_gating.py`

Note: generated `test_project/settings.py` still has pre-existing ruff findings unrelated to this change (`I001` import order and `F541` on `MEDIA_URL = f"/media/"`), so I linted the changed generated adapters/tests directly.
