### PR TITLE
Apply FileBridge auth learnings to starter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Post-generation hook now creates fresh initial migrations after cookiecutter option cleanup, avoiding static template migrations while keeping generated projects deploy-ready.
+- Generated projects now include styled django-allauth email/passkey/MFA account templates, post-registration passkey setup links, and hardened WebAuthn login JavaScript.
 - Generated projects now include an `ALLOW_SIGNUPS` environment flag (default `True`) to pause new email/social registrations while keeping existing user logins available.
 - Generated projects with `generate_blog = y` now include a superuser-only admin blog API for creating, listing, reading, updating, patching, deleting, reviewing, and publishing blog posts.
 - Passkey authentication (WebAuthn) in generated projects: sign in + sign up flows via `django-allauth` MFA.
@@ -40,6 +42,9 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - npm lint command
 
 ### Changed
+- Generated signup/login now defaults to email + password, non-blocking email-link verification, and passkey setup after registration instead of passkey signup.
+- Generated transactional email sender defaults can now be configured with `MAILGUN_SENDER_DOMAIN`, `DEFAULT_FROM_EMAIL`, and `SERVER_EMAIL` environment variables.
+- Generated deployment entrypoints now wait for the database, run commands with `exec`, and Dockerfiles explicitly make the entrypoint executable.
 - Generated Sentry configuration now enables richer observability defaults: release metadata, configurable tracing/profiling/log settings, logging breadcrumbs/events, and the existing `before_send` hook.
 - Updated root test tooling and generated project Python dependency minimums to current PyPI releases.
 - Transactional email delivery in generated projects now retries transient failures, emits structured observability fields/counters, and avoids bubbling email send errors into user-facing 500s for confirmation + feedback flows.
@@ -60,6 +65,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
   - No need for requirements.txt file
 
 ### Fixed
+- Generated settings-page confirmation resends now use django-allauth's canonical email verification flow, avoiding invalid confirmation links and duplicate success notifications.
 - Generated projects with `use_stripe = n` now keep `ProfileSettingsOut` syntactically valid when importing API schemas.
 - Fresh local boot now uses Node 24 for the frontend dev container, waits for the frontend manifest healthcheck before starting the backend, and keeps Tailwind imports ordered so default builds avoid the PostCSS import warning.
 - DEBUG-mode settings now allow tunnel-based local development (localhost, backend, ngrok/trycloudflare/loca.lt CSRF origins) while keeping non-DEBUG host/CSRF restrictions scoped to `SITE_URL`.

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -3,6 +3,7 @@
 
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 
@@ -64,6 +65,60 @@ def remove_ci_workflow():
         print("Removed CI workflow")
 
 
+def generate_initial_migrations():
+    """Generate fresh initial migrations after cookiecutter option cleanup."""
+    if os.environ.get("SKIP_POST_GEN_MIGRATIONS") == "1":
+        print("Skipping migration generation because SKIP_POST_GEN_MIGRATIONS=1")
+        return
+
+    if shutil.which("uv") is None:
+        print("uv not found; run `uv run python manage.py makemigrations` after generation.")
+        return
+
+    env = os.environ.copy()
+    env.setdefault("ENVIRONMENT", "dev")
+    env.setdefault("SECRET_KEY", "post-generation-migrations")
+    env.setdefault("DEBUG", "True")
+    env.setdefault("SITE_URL", "http://localhost:8000")
+    env.setdefault("POSTGRES_DB", "postgres")
+    env.setdefault("POSTGRES_USER", "postgres")
+    env.setdefault("POSTGRES_PASSWORD", "postgres")
+    env.setdefault("POSTGRES_HOST", "localhost")
+    env.setdefault("POSTGRES_PORT", "5432")
+
+    settings_module_path = Path("{{ cookiecutter.project_slug }}") / "_post_gen_migration_settings.py"
+    settings_module_path.write_text(
+        "from .settings import *  # noqa\n"
+        "DATABASES = {\n"
+        "    'default': {\n"
+        "        'ENGINE': 'django.db.backends.sqlite3',\n"
+        "        'NAME': BASE_DIR / '.post_gen_migrations.sqlite3',\n"
+        "    }\n"
+        "}\n",
+        encoding="utf-8",
+    )
+
+    print("Generating fresh initial migrations...")
+    try:
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "python",
+                "manage.py",
+                "makemigrations",
+                "--settings",
+                "{{ cookiecutter.project_slug }}._post_gen_migration_settings",
+                "--noinput",
+            ],
+            check=True,
+            env=env,
+        )
+    finally:
+        settings_module_path.unlink(missing_ok=True)
+        Path(".post_gen_migrations.sqlite3").unlink(missing_ok=True)
+
+
 def main():
     """Run post-generation tasks."""
     generate_blog = "{{ cookiecutter.generate_blog }}"
@@ -92,6 +147,8 @@ def main():
         print("CI disabled, removing CI workflow...")
         remove_ci_workflow()
         print("CI cleanup complete!")
+
+    generate_initial_migrations()
 
 
 if __name__ == "__main__":

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -98,6 +98,26 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     # optional apps on by default in this test helper
     assert (project_dir / "apps" / "blog").exists()
     assert (project_dir / "apps" / "docs").exists()
+    assert not (
+        Path(__file__).resolve().parents[1]
+        / "{{ cookiecutter.project_slug }}"
+        / "apps"
+        / "core"
+        / "migrations"
+        / "0002_initial.py"
+    ).exists()
+    assert (project_dir / "apps" / "core" / "migrations" / "0002_initial.py").exists()
+    assert (project_dir / "apps" / "pages" / "migrations" / "0001_initial.py").exists()
+    assert (project_dir / "apps" / "blog" / "migrations" / "0001_initial.py").exists()
+
+    _assert_contains(project_dir / "deployment" / "entrypoint.sh", "wait_for_database")
+    _assert_contains(project_dir / "deployment" / "entrypoint.sh", "exec gunicorn")
+    _assert_contains(project_dir / "deployment" / "Dockerfile.server", "chmod +x deployment/entrypoint.sh")
+    _assert_contains(project_dir / "deployment" / "Dockerfile.server", '["sh", "deployment/entrypoint.sh", "-s"]')
+    _assert_contains(
+        Path(__file__).resolve().parents[1] / "hooks" / "post_gen_project.py",
+        "Generating fresh initial migrations",
+    )
 
     # optional CI on by default
     assert (project_dir / ".github" / "workflows" / "ci.yml").exists()
@@ -115,8 +135,10 @@ def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
 
     _assert_contains(project_dir / "pyproject.toml", "fido2>=2.2.0,<3")
     _assert_contains(settings_py, '"allauth.mfa"')
-    _assert_contains(settings_py, 'ACCOUNT_EMAIL_VERIFICATION = "mandatory"')
-    _assert_contains(settings_py, "ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True")
+    _assert_contains(settings_py, 'ACCOUNT_LOGIN_METHODS = {"email"}')
+    _assert_contains(settings_py, 'ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*"]')
+    _assert_contains(settings_py, 'ACCOUNT_EMAIL_VERIFICATION = "optional"')
+    _assert_contains(settings_py, "ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = False")
     _assert_contains(settings_py, "EMAIL_DELIVERY_RETRY_BACKOFF_SECONDS = (0.0, 1.0, 3.0)")
     _assert_contains(settings_py, 'SITE_HOST = SITE_URL.replace("http://", "").replace("https://", "").split("/")[0].split(":")[0]')
     _assert_contains(settings_py, 'ALLOWED_HOSTS = [SITE_HOST]')
@@ -129,11 +151,13 @@ def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
     _assert_contains(settings_py, '"https://*.trycloudflare.com"')
     _assert_contains(settings_py, '"https://*.loca.lt"')
     _assert_contains(settings_py, "MFA_PASSKEY_LOGIN_ENABLED = True")
-    _assert_contains(settings_py, "MFA_PASSKEY_SIGNUP_ENABLED = True")
+    _assert_contains(settings_py, "MFA_PASSKEY_SIGNUP_ENABLED = False")
     _assert_contains(settings_py, "MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG")
     _assert_contains(settings_py, 'ALLOW_SIGNUPS = env.bool("ALLOW_SIGNUPS", default=True)')
 
     _assert_contains(project_dir / ".env.example", "ALLOW_SIGNUPS=True")
+    _assert_contains(project_dir / ".env.example", "MAILGUN_SENDER_DOMAIN=mg.test_project.app")
+    _assert_contains(settings_py, 'env("MAILGUN_SENDER_DOMAIN", default="mg.test_project.app")')
     _assert_contains(
         project_dir / "apps" / "docs" / "content" / "deployment" / "environment-variables.md",
         "**ALLOW_SIGNUPS**",
@@ -156,12 +180,47 @@ def test_default_generation_includes_passkey_auth(tmp_path: Path) -> None:
         "Sign in with a passkey",
     )
     _assert_contains(
+        project_dir
+        / "frontend"
+        / "templates"
+        / "mfa"
+        / "webauthn"
+        / "snippets"
+        / "login_script.html",
+        "window.webauthnJSON.get(requestOptions)",
+    )
+    _assert_not_contains(
         project_dir / "frontend" / "templates" / "account" / "signup.html",
         "Sign up using a passkey",
     )
     _assert_contains(
-        project_dir / "frontend" / "templates" / "account" / "signup_by_passkey.html",
-        "Continue with passkey",
+        project_dir / "frontend" / "templates" / "pages" / "user-settings.html",
+        "Add passkey",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "mfa" / "index.html",
+        "Passkeys",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "email.html",
+        "Email addresses",
+    )
+
+
+def test_generated_mfa_templates_use_configured_project_colour(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path, project_main_color="purple")
+
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "mfa" / "webauthn" / "add_form.html",
+        "bg-purple-600",
+    )
+    _assert_contains(
+        project_dir / "frontend" / "templates" / "account" / "email.html",
+        "focus:ring-purple-500",
+    )
+    _assert_not_contains(
+        project_dir / "frontend" / "templates" / "mfa" / "webauthn" / "add_form.html",
+        "green-",
     )
 
 
@@ -391,6 +450,8 @@ def test_generated_project_does_not_contain_unrendered_cookiecutter_vars(tmp_pat
             continue
 
         rel = path.relative_to(project_dir)
+        if rel.parts[0] == ".venv":
+            continue
         if rel in allowlist:
             continue
 
@@ -416,6 +477,8 @@ def test_generated_project_does_not_contain_template_author_leaks(tmp_path: Path
 
     for path in project_dir.rglob("*"):
         if not path.is_file():
+            continue
+        if path.relative_to(project_dir).parts[0] == ".venv":
             continue
         if path.suffix in {".png", ".jpg", ".jpeg", ".gif", ".ico", ".woff", ".woff2"}:
             continue

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -50,6 +50,9 @@ AWS_S3_BUCKET_NAME={{ cookiecutter.project_slug }}
 # If you don't specify the key you will get the link to confirm email
 # in your logs
 MAILGUN_API_KEY=
+MAILGUN_SENDER_DOMAIN=mg.{{ cookiecutter.project_slug }}.app
+DEFAULT_FROM_EMAIL={{ cookiecutter.author_name }} from {{ cookiecutter.project_name }} <hello@{{ cookiecutter.project_slug }}.app>
+SERVER_EMAIL={{ cookiecutter.project_name }} Errors <error@{{ cookiecutter.project_slug }}.app>
 
 {% if cookiecutter.use_buttondown == 'y' -%}
 # If you plan on doing a newsletter for subscribers

--- a/{{ cookiecutter.project_slug }}/apps/core/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/views.py
@@ -3,7 +3,11 @@ from urllib.parse import urlencode
 {% if cookiecutter.use_stripe == 'y' -%}
 import stripe
 {% endif %}
-from allauth.account.models import EmailAddress, EmailConfirmation
+from allauth.account.internal.flows.email_verification import (
+    send_verification_email_to_address,
+)
+from allauth.account.models import EmailAddress
+from allauth.mfa.models import Authenticator
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.cache import cache
@@ -69,9 +73,13 @@ class UserSettingsView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         context = super().get_context_data(**kwargs)
         user = self.request.user
 
-        email_address = EmailAddress.objects.get_for_user(user, user.email)
-        context["email_verified"] = email_address.verified
+        email_address = EmailAddress.objects.filter(user=user, email__iexact=user.email).first()
+        context["email_verified"] = bool(email_address and email_address.verified)
         context["resend_confirmation_url"] = reverse("resend_confirmation")
+        context["passkey_count"] = Authenticator.objects.filter(
+            user=user,
+            type=Authenticator.Type.WEBAUTHN,
+        ).count()
         {% if cookiecutter.use_stripe == 'y' -%}
         context["has_subscription"] = user.profile.has_active_subscription
         {% endif %}
@@ -81,11 +89,12 @@ class UserSettingsView(LoginRequiredMixin, SuccessMessageMixin, UpdateView):
         return context
 
 @login_required
+@require_POST
 def resend_confirmation_email(request):
     user = request.user
 
     try:
-        email_address = EmailAddress.objects.get_for_user(user, user.email)
+        email_address = EmailAddress.objects.filter(user=user, email__iexact=user.email).first()
 
         if not email_address:
             messages.error(request, "No email address found for your account.")
@@ -105,11 +114,13 @@ def resend_confirmation_email(request):
             )
             return redirect("settings")
 
-        # Create or get existing email confirmation
-        email_confirmation = EmailConfirmation.create(email_address)
-        email_confirmation.send(request, signup=False)
-
-        messages.success(request, "Confirmation email has been sent. Please check your inbox.")
+        sent = send_verification_email_to_address(request, email_address, signup=False)
+        if not sent:
+            messages.error(
+                request,
+                "Please wait before requesting another confirmation email.",
+            )
+            return redirect("settings")
         logger.info(
             "[Resend Confirmation] Email sent successfully",
             user_id=user.id,

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
@@ -192,6 +192,19 @@ Configure these to send emails from {{ cookiecutter.project_name }} (for notific
 - Used for sending transactional emails
 - Leave empty to use console email backend (emails printed to console)
 
+**MAILGUN_SENDER_DOMAIN**
+- Mailgun sender domain for transactional email
+- Defaults to `mg.{{ cookiecutter.project_slug }}.app`
+- Override this when the project sends from another verified Mailgun domain
+
+**DEFAULT_FROM_EMAIL**
+- Default visible sender for transactional email
+- Defaults to `{{ cookiecutter.author_name }} from {{ cookiecutter.project_name }} <hello@{{ cookiecutter.project_slug }}.app>`
+
+**SERVER_EMAIL**
+- Sender used for server/admin error emails
+- Defaults to `{{ cookiecutter.project_name }} Errors <error@{{ cookiecutter.project_slug }}.app>`
+
 ### OAuth/Social Authentication
 
 **GITHUB_CLIENT_ID**

--- a/{{ cookiecutter.project_slug }}/apps/pages/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/pages/tests.py
@@ -1,6 +1,12 @@
-import pytest
-from django.urls import reverse
+import time
 
+import pytest
+from allauth.account.models import EmailAddress
+from allauth.mfa.models import Authenticator
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.messages import get_messages
+from django.urls import reverse
 
 pytestmark = pytest.mark.django_db
 
@@ -12,20 +18,324 @@ def test_login_page_shows_passkey_option(client):
     content = response.content.decode()
     assert "Sign in with a passkey" in content
     assert 'id="mfa_login"' in content
+    assert "window.webauthnJSON.get(requestOptions)" in content
+    assert "X-Requested-With" in content
+    assert "allauth.webauthn.forms.loginForm" not in content
 
 
-def test_signup_page_shows_passkey_option(client):
+def test_signup_page_hides_passkey_signup_option(client):
     response = client.get(reverse("account_signup"))
     assert response.status_code == 200
 
     content = response.content.decode()
-    assert "Sign up using a passkey" in content
+    assert "Username" not in content
+    assert "Confirm Password" not in content
+    assert "Cofirm Password" not in content
+    assert "Sign up using a passkey" not in content
 
 
-def test_passkey_signup_page_uses_custom_template(client):
-    response = client.get(reverse("account_signup_by_passkey"))
+def test_login_page_uses_email_instead_of_username(client):
+    response = client.get(reverse("account_login"))
     assert response.status_code == 200
 
     content = response.content.decode()
-    assert "Create your account with a passkey" in content
-    assert "Continue with passkey" in content
+    assert 'placeholder="Email"' in content
+    assert 'type="email"' in content
+    assert 'placeholder="Username"' not in content
+
+
+def test_signup_redirects_to_dashboard_without_blocking_email_code_page(
+    client, monkeypatch, settings
+):
+    sent_confirmations = []
+
+    def fake_send_confirmation_mail(self, request, emailconfirmation, signup):
+        sent_confirmations.append((emailconfirmation.email_address.email, signup))
+
+    monkeypatch.setattr(
+        "{{ cookiecutter.project_slug }}.adapters.CustomAccountAdapter.send_confirmation_mail",
+        fake_send_confirmation_mail,
+    )
+    {% if cookiecutter.use_posthog == 'y' -%}
+    settings.POSTHOG_API_KEY = ""
+    {% endif %}
+
+    response = client.post(
+        reverse("account_signup"),
+        data={
+            "email": "newuser@example.com",
+            "password1": "strong-test-pass-123",
+        },
+    )
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("home")
+    user = get_user_model().objects.get(email="newuser@example.com")
+    assert user.username
+    assert sent_confirmations == [("newuser@example.com", True)]
+
+
+def test_dashboard_does_not_show_email_confirmation_reminder(client):
+    user = get_user_model().objects.create_user(
+        username="unverified",
+        email="unverified@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("home"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Your email is not yet confirmed" not in content
+    assert "Welcome to {{ cookiecutter.project_name }}" in content
+
+
+def test_settings_shows_email_confirmation_and_passkey_setup(client):
+    user = get_user_model().objects.create_user(
+        username="settingsuser",
+        email="settingsuser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("settings"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Your email is not yet confirmed" in content
+    assert "Add passkey" in content
+    assert reverse("mfa_add_webauthn") in content
+
+
+def test_settings_handles_users_without_allauth_email_address(client):
+    user = get_user_model().objects.create_user(
+        username="noemailaddress",
+        email="noemailaddress@example.com",
+        password="strong-test-pass-123",
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("settings"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Your email is not yet confirmed" in content
+    assert "Add passkey" in content
+
+
+def test_settings_shows_passkey_manage_link_when_passkey_exists(client):
+    user = get_user_model().objects.create_user(
+        username="passkeyuser",
+        email="passkeyuser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": True},
+    )
+    Authenticator.objects.create(
+        user=user,
+        type=Authenticator.Type.WEBAUTHN,
+        data={"name": "Test passkey"},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("settings"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "You have 1 passkey set up." in content
+    assert "Manage passkeys" in content
+    assert reverse("mfa_list_webauthn") in content
+
+
+def test_mfa_index_uses_app_styling(client):
+    user = get_user_model().objects.create_user(
+        username="mfauser",
+        email="mfauser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": True},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("mfa_index"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Passkeys" in content
+    assert "Add passkey" in content
+    assert "Menu:" not in content
+
+
+def test_webauthn_add_page_loads_styled_form_and_scripts(client):
+    user = get_user_model().objects.create_user(
+        username="addpasskeyuser",
+        email="addpasskeyuser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": True},
+    )
+    assert client.login(username="addpasskeyuser", password="strong-test-pass-123")
+    session = client.session
+    session["account_authentication_methods"] = [
+        {"method": "password", "at": time.time(), "username": "addpasskeyuser"}
+    ]
+    session.save()
+
+    response = client.get(reverse("mfa_add_webauthn"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Add passkey" in content
+    assert 'id="mfa_webauthn_add"' in content
+    assert "allauth.webauthn.forms.addForm" in content
+    assert "mfa/js/webauthn.js" in content
+    assert "Menu:" not in content
+
+
+def test_reauthenticate_page_uses_app_styling(client):
+    user = get_user_model().objects.create_user(
+        username="reauthuser",
+        email="reauthuser@example.com",
+        password="strong-test-pass-123",
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("account_reauthenticate"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Confirm access" in content
+    assert "Menu:" not in content
+
+
+def test_account_email_page_uses_app_styling(client):
+    user = get_user_model().objects.create_user(
+        username="emailpageuser",
+        email="emailpageuser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("account_email"))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "Email addresses" in content
+    assert "Re-send verification" in content
+    assert "Menu:" not in content
+
+
+def test_settings_resend_confirmation_uses_hmac_link(client, monkeypatch):
+    sent_confirmations = []
+
+    def fake_send_confirmation_mail(self, request, emailconfirmation, signup):
+        sent_confirmations.append((emailconfirmation, signup))
+
+    monkeypatch.setattr(
+        "{{ cookiecutter.project_slug }}.adapters.CustomAccountAdapter.send_confirmation_mail",
+        fake_send_confirmation_mail,
+    )
+    user = get_user_model().objects.create_user(
+        username="resenduser",
+        email="resenduser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.post(reverse("resend_confirmation"))
+
+    assert response.status_code == 302
+    assert response["Location"] == reverse("settings")
+    assert len(list(get_messages(response.wsgi_request))) == 1
+    assert len(sent_confirmations) == 1
+    emailconfirmation, signup = sent_confirmations[0]
+    assert signup is False
+    assert emailconfirmation.key.count(":") == 2
+    assert not EmailAddress.objects.get(user=user, email=user.email).verified
+
+
+def test_settings_resend_confirmation_requires_post(client):
+    user = get_user_model().objects.create_user(
+        username="resendgetuser",
+        email="resendgetuser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.get(reverse("resend_confirmation"))
+
+    assert response.status_code == 405
+
+
+def test_settings_resend_confirmation_link_confirms_email(client, monkeypatch):
+    sent_confirmations = []
+
+    def fake_send_confirmation_mail(self, request, emailconfirmation, signup):
+        sent_confirmations.append(emailconfirmation)
+
+    monkeypatch.setattr(
+        "{{ cookiecutter.project_slug }}.adapters.CustomAccountAdapter.send_confirmation_mail",
+        fake_send_confirmation_mail,
+    )
+    user = get_user_model().objects.create_user(
+        username="confirmresenduser",
+        email="confirmresenduser@example.com",
+        password="strong-test-pass-123",
+    )
+    EmailAddress.objects.update_or_create(
+        user=user,
+        email=user.email,
+        defaults={"primary": True, "verified": False},
+    )
+    client.force_login(user)
+
+    response = client.post(reverse("resend_confirmation"))
+
+    assert response.status_code == 302
+    assert len(sent_confirmations) == 1
+    confirm_path = reverse("account_confirm_email", args=[sent_confirmations[0].key])
+    confirm_response = client.post(confirm_path)
+
+    assert confirm_response.status_code == 302
+    assert EmailAddress.objects.get(user=user, email=user.email).verified is True
+
+
+def test_mailgun_sender_defaults_are_configurable():
+    assert settings.DEFAULT_FROM_EMAIL == "{{ cookiecutter.author_name }} from {{ cookiecutter.project_name }} <hello@{{ cookiecutter.project_slug }}.app>"
+    assert settings.SERVER_EMAIL == "{{ cookiecutter.project_name }} Errors <error@{{ cookiecutter.project_slug }}.app>"
+    assert settings.ANYMAIL["MAILGUN_SENDER_DOMAIN"] == "mg.{{ cookiecutter.project_slug }}.app"

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
@@ -21,8 +21,9 @@ RUN pip install --no-cache-dir uv
 RUN uv sync --no-dev --no-install-project
 
 COPY . .
+RUN chmod +x deployment/entrypoint.sh
 COPY --from=build /app/frontend/build/ ./frontend/build/
 
 EXPOSE 80
 
-CMD ["deployment/entrypoint.sh", "-s"]
+CMD ["sh", "deployment/entrypoint.sh", "-s"]

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
@@ -21,8 +21,9 @@ RUN pip install --no-cache-dir uv
 RUN uv sync --no-dev --no-install-project
 
 COPY . .
+RUN chmod +x deployment/entrypoint.sh
 COPY --from=build /app/frontend/build/ ./frontend/build/
 
 EXPOSE 80
 
-CMD ["deployment/entrypoint.sh", "-w"]
+CMD ["sh", "deployment/entrypoint.sh", "-w"]

--- a/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 # Default to server command if no arguments provided
 if [ $# -eq 0 ]; then
@@ -8,31 +9,55 @@ else
     server=false
 fi
 
-# All commands before the conditional ones
 export PROJECT_NAME={{ cookiecutter.project_slug }}
-
 export DJANGO_SETTINGS_MODULE="{{ cookiecutter.project_slug }}.settings"
 
 while getopts ":sw" option; do
     case "${option}" in
-        s)  # Run server
-            server=true
-            ;;
-        w)  # Run worker
-            server=false
-            ;;
-        *)  # Invalid option
-            echo "Invalid option: -$OPTARG" >&2
-            ;;
+        s) server=true ;;
+        w) server=false ;;
+        *) echo "Invalid option: -$OPTARG" >&2 ;;
     esac
 done
 shift $((OPTIND - 1))
 
-# If no valid option provided, default to server
+wait_for_database() {
+    echo "Waiting for database..."
+    python - <<'PY'
+import os
+import sys
+import time
+
+import django
+from django.db import connections
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ cookiecutter.project_slug }}.settings")
+django.setup()
+
+last_error = None
+for attempt in range(1, 61):
+    try:
+        connections["default"].ensure_connection()
+        print("Database is ready.")
+        sys.exit(0)
+    except Exception as exc:
+        last_error = exc
+        print(f"Database unavailable, retrying ({attempt}/60): {exc}", flush=True)
+        time.sleep(2)
+
+print(f"Database did not become ready: {last_error}", file=sys.stderr)
+sys.exit(1)
+PY
+}
+
+wait_for_database
+
 if [ "$server" = true ]; then
+    echo "Starting {{ cookiecutter.project_name }} server..."
     python manage.py collectstatic --noinput
-    python manage.py migrate
-    gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
+    python manage.py migrate --noinput
+    exec gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
 else
-    python manage.py qcluster
+    echo "Starting {{ cookiecutter.project_name }} workers..."
+    exec python manage.py qcluster
 fi

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/email.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/email.html
@@ -1,0 +1,76 @@
+{% raw %}
+{% extends 'base_app.html' %}
+{% load widget_tweaks %}
+
+{% block meta %}
+<title>Email addresses · the app</title>
+{% endblock meta %}
+
+{% block content %}
+<div class="px-4 py-12 mx-auto max-w-3xl sm:px-6 lg:px-8">
+  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-8">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+      <div>
+        <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Email addresses</h1>
+        <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Manage the email addresses associated with your your account.</p>
+      </div>
+      <a href="{% url 'settings' %}" class="text-sm font-medium text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-400 dark:hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-300">Back to settings</a>
+    </div>
+
+    {% if emailaddresses %}
+      <form class="mt-8 space-y-5" method="post" action="{% url 'account_email' %}">
+        {% csrf_token %}
+        <fieldset class="space-y-3">
+          <legend class="sr-only">Email addresses</legend>
+          {% for radio in emailaddress_radios %}
+            {% with emailaddress=radio.emailaddress %}
+              <label for="{{ radio.id }}" class="flex items-start gap-3 rounded-xl border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+                <input id="{{ radio.id }}" type="radio" name="email" value="{{ emailaddress.email }}" {% if radio.checked %}checked{% endif %} class="mt-1 h-4 w-4 border-gray-300 text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500">
+                <span class="min-w-0 flex-1">
+                  <span class="block break-all font-medium text-gray-900 dark:text-gray-100">{{ emailaddress.email }}</span>
+                  <span class="mt-2 flex flex-wrap gap-2">
+                    {% if emailaddress.verified %}
+                      <span class="inline-flex rounded-full bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-100 px-2.5 py-0.5 text-xs font-medium text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-800 dark:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-900/40 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-200">Verified</span>
+                    {% else %}
+                      <span class="inline-flex rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-200">Unverified</span>
+                    {% endif %}
+                    {% if emailaddress.primary %}
+                      <span class="inline-flex rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-200">Primary</span>
+                    {% endif %}
+                  </span>
+                </span>
+              </label>
+            {% endwith %}
+          {% endfor %}
+        </fieldset>
+
+        <div class="flex flex-col gap-2 sm:flex-row sm:flex-wrap">
+          <button type="submit" name="action_primary" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Make primary</button>
+          <button type="submit" name="action_send" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Re-send verification</button>
+          <button type="submit" name="action_remove" class="inline-flex justify-center rounded-md border border-red-300 bg-white px-4 py-2 text-sm font-medium text-red-700 shadow-sm hover:bg-red-50 dark:border-red-900/70 dark:bg-gray-900 dark:text-red-300 dark:hover:bg-red-950/40">Remove</button>
+        </div>
+      </form>
+    {% else %}
+      <p class="mt-8 rounded-xl border border-yellow-200 bg-yellow-50 p-4 text-sm text-yellow-800 dark:border-yellow-900/60 dark:bg-yellow-950/30 dark:text-yellow-200">No email address is currently associated with your account.</p>
+    {% endif %}
+
+    {% if can_add_email %}
+      <div class="mt-10 border-t border-gray-200 pt-8 dark:border-gray-800">
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Add email address</h2>
+        <form class="mt-4 space-y-4" method="post" action="{% url 'account_email' %}">
+          {% csrf_token %}
+          {{ form.non_field_errors|safe }}
+          <div>
+            {{ form.email.errors|safe }}
+            <label for="{{ form.email.id_for_label }}" class="sr-only">Email address</label>
+            {% render_field form.email placeholder="Email address" type="email" autocomplete="email" class="block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-500 shadow-sm focus:border-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:outline-none focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 sm:text-sm" %}
+          </div>
+          <button type="submit" name="action_add" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Add email</button>
+        </form>
+      </div>
+    {% endif %}
+  </div>
+</div>
+{% endblock content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/login.html
@@ -23,8 +23,8 @@
                 <div class="-space-y-px rounded-md shadow-sm">
                     <div>
                         {{ "{{ form.login.errors | safe }}" }}
-                        <label for="username" class="sr-only">Username</label>
-                        {{ '{% render_field form.login placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
+                        <label for="email" class="sr-only">Email</label>
+                        {{ '{% render_field form.login placeholder="Email" id="email" name="login" type="email" autocomplete="email" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{{cookiecutter.project_main_color}}-500 focus:border-{{cookiecutter.project_main_color}}-500 focus:z-10 sm:text-sm" %}' }}
                     </div>
                     <div>
                         {{ "{{ form.password.errors | safe }}" }}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/reauthenticate.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/reauthenticate.html
@@ -1,0 +1,26 @@
+{% raw %}
+{% extends 'base_app.html' %}
+{% load widget_tweaks %}
+
+{% block content %}
+  <div class="flex justify-center items-center px-4 py-12 my-4 sm:px-6 lg:px-8">
+    <div class="w-full max-w-md rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-8">
+      <h1 class="text-2xl font-bold tracking-tight text-center text-gray-900 dark:text-gray-100">Confirm access</h1>
+      <p class="mt-2 text-sm text-center text-gray-600 dark:text-gray-300">Enter your password to continue changing account security settings.</p>
+
+      <form class="mt-8 space-y-6" method="post" action="{% url 'account_reauthenticate' %}">
+        {% csrf_token %}
+        {{ form.non_field_errors|safe }}
+        {{ redirect_field }}
+        <div>
+          {{ form.password.errors|safe }}
+          <label for="{{ form.password.id_for_label }}" class="sr-only">Password</label>
+          {% render_field form.password placeholder="Password" autocomplete="current-password" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-950 dark:text-gray-100 dark:placeholder-gray-400 rounded-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:border-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 sm:text-sm" %}
+        </div>
+        <button type="submit" class="flex w-full justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Continue</button>
+      </form>
+    </div>
+  </div>
+{% endblock content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/account/signup.html
@@ -23,24 +23,14 @@
         <input type="hidden" name="remember" value="true" />
         <div class="-space-y-px rounded-md shadow-sm">
           <div>
-            {{ "{{ form.username.errors | safe }}" }}
-            <label for="username" class="sr-only">Username</label>
-            {% raw %}{% render_field form.username placeholder="Username" id="username" name="username" type="text" autocomplete="username" required=True class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
-          </div>
-          <div>
             {{ "{{ form.email.errors | safe }}" }}
-            <label for="email" class="sr-only">Username</label>
-            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
+            <label for="email" class="sr-only">Email</label>
+            {% raw %}{% render_field form.email id="email" name="email" placeholder="Email" type="email" autocomplete="email" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-t-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
           </div>
           <div>
             {{ "{{ form.password1.errors | safe }}" }}
             <label for="password1" class="sr-only">Password</label>
-            {% raw %}{% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
-          </div>
-          <div>
-            {{ "{{ form.password2.errors | safe }}" }}
-            <label for="password2" class="sr-only">Password</label>
-            {% raw %}{% render_field form.password2 id="password2" name="password2" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-b-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" placeholder="Cofirm Password" %}{%- endraw %}
+            {% raw %}{% render_field form.password1 id="password1" name="password1" placeholder="Password" type="password" autocomplete="current-password" required="True" class="block relative px-3 py-2 w-full placeholder-gray-500 text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100 dark:placeholder-gray-400 rounded-none rounded-b-md border border-gray-300 dark:border-gray-700 appearance-none focus:outline-none focus:ring-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:border-{%- endraw %}{{cookiecutter.project_main_color}}{% raw %}-500 focus:z-10 sm:text-sm" %}{%- endraw %}
           </div>
         </div>
 
@@ -67,26 +57,6 @@
             </button>
         </div>
       </form>
-
-      {{ "{% if PASSKEY_SIGNUP_ENABLED %}" }}
-      <div>
-        <div class="relative mt-10">
-          <div class="flex absolute inset-0 items-center" aria-hidden="true">
-            <div class="w-full border-t border-gray-200 dark:border-gray-700"></div>
-          </div>
-          <div class="flex relative justify-center text-sm font-medium leading-6">
-            <span class="px-6 text-gray-900 bg-white dark:text-gray-100 dark:bg-gray-900">Passkey</span>
-          </div>
-        </div>
-
-        <div class="mt-6">
-          <a href="{% raw %}{{ signup_by_passkey_url }}{%- endraw %}"
-             class="flex justify-center px-4 py-2 w-full text-sm font-medium text-gray-900 bg-white rounded-md border border-gray-300 border-solid hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-{{cookiecutter.project_main_color}}-500 dark:text-gray-100 dark:bg-gray-900 dark:border-gray-700 dark:hover:bg-gray-800">
-            Sign up using a passkey
-          </a>
-        </div>
-      </div>
-      {{ "{% endif %}" }}
 
       {{ "{% if has_social_providers %}" }}
       <div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/base_manage.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/base_manage.html
@@ -1,0 +1,12 @@
+{% raw %}
+{% extends "base_app.html" %}
+
+{% block content %}
+<div class="px-4 py-12 mx-auto max-w-3xl sm:px-6 lg:px-8">
+  <div class="rounded-2xl border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-8">
+    {% block mfa_content %}{% endblock mfa_content %}
+  </div>
+</div>
+{% endblock content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/index.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/index.html
@@ -1,0 +1,48 @@
+{% raw %}
+{% extends "mfa/base_manage.html" %}
+{% load i18n %}
+
+{% block meta %}
+<title>Passkeys · the app</title>
+{% endblock meta %}
+
+{% block mfa_content %}
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Passkeys</h1>
+      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        Add a passkey to sign in faster and more securely with your device unlock, fingerprint, or face ID.
+      </p>
+    </div>
+    <a href="{% url 'settings' %}" class="text-sm font-medium text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-400 dark:hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-300">Back to settings</a>
+  </div>
+
+  {% if "webauthn" in MFA_SUPPORTED_TYPES %}
+    <div class="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-5 dark:border-gray-700 dark:bg-gray-800/50">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-gray-100">Your passkeys</h2>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            {% if authenticators.webauthn|length %}
+              You have added {{ authenticators.webauthn|length }} passkey{{ authenticators.webauthn|length|pluralize }}.
+            {% else %}
+              No passkeys have been added yet.
+            {% endif %}
+          </p>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row">
+          {% if authenticators.webauthn|length %}
+            <a href="{% url 'mfa_list_webauthn' %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Manage</a>
+          {% endif %}
+          <a href="{% url 'mfa_add_webauthn' %}" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Add passkey</a>
+        </div>
+      </div>
+    </div>
+  {% endif %}
+
+  <p class="mt-6 text-xs leading-5 text-gray-500 dark:text-gray-400">
+    Note: the app requires a confirmed email address before adding passkeys, so account recovery remains safe.
+  </p>
+{% endblock mfa_content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/add_form.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/add_form.html
@@ -1,0 +1,62 @@
+{% raw %}
+{% extends "mfa/webauthn/base.html" %}
+{% load widget_tweaks %}
+
+{% block mfa_content %}
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Add passkey</h1>
+      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">
+        Use your device unlock, fingerprint, or face ID to create a passkey for this your account.
+      </p>
+    </div>
+    <a href="{% url 'mfa_index' %}" class="text-sm font-medium text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-400 dark:hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-300">Back to passkeys</a>
+  </div>
+
+  <form class="mt-8 space-y-6" method="post" action="{% url 'mfa_add_webauthn' %}">
+    {% csrf_token %}
+    {{ form.non_field_errors|safe }}
+    {% for field in form.hidden_fields %}{{ field }}{% endfor %}
+
+    <div class="space-y-4">
+      <div>
+        {{ form.name.errors|safe }}
+        <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-gray-900 dark:text-gray-100">Passkey name</label>
+        {% render_field form.name class="mt-2 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-500 shadow-sm focus:border-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:outline-none focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 sm:text-sm" %}
+      </div>
+
+      {% if form.passwordless %}
+        <div class="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+          <label class="flex gap-3 text-sm text-gray-700 dark:text-gray-200" for="{{ form.passwordless.id_for_label }}">
+            {% render_field form.passwordless class="mt-1 h-4 w-4 rounded border-gray-300 text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500" %}
+            <span>
+              <span class="font-medium text-gray-900 dark:text-gray-100">Enable passwordless sign in</span>
+              <span class="mt-1 block text-gray-600 dark:text-gray-300">This lets you sign in using only the passkey when your device supports biometric or PIN verification.</span>
+            </span>
+          </label>
+          {{ form.passwordless.errors|safe }}
+        </div>
+      {% endif %}
+    </div>
+
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <button id="mfa_webauthn_add" type="button" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">
+        Add passkey
+      </button>
+      <a href="{% url 'mfa_index' %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Cancel</a>
+    </div>
+  </form>
+
+  {% include "mfa/webauthn/snippets/scripts.html" %}
+  {{ js_data|json_script:"js_data" }}
+  <script data-allauth-onload="allauth.webauthn.forms.addForm" type="application/json">{
+    "ids": {
+      "add": "mfa_webauthn_add",
+      "passwordless": "{{ form.passwordless.auto_id }}",
+      "credential": "{{ form.credential.auto_id }}",
+      "data": "js_data"
+    }
+  }</script>
+{% endblock mfa_content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/authenticator_confirm_delete.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/authenticator_confirm_delete.html
@@ -1,0 +1,15 @@
+{% raw %}
+{% extends "mfa/webauthn/base.html" %}
+
+{% block mfa_content %}
+  <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Remove passkey</h1>
+  <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Are you sure you want to remove this passkey from your your account?</p>
+
+  <form class="mt-8 flex flex-col gap-3 sm:flex-row" method="post" action="{% url 'mfa_remove_webauthn' pk=authenticator.pk %}">
+    {% csrf_token %}
+    <button type="submit" class="inline-flex justify-center rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Remove passkey</button>
+    <a href="{% url 'mfa_list_webauthn' %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Cancel</a>
+  </form>
+{% endblock mfa_content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/authenticator_list.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/authenticator_list.html
@@ -1,0 +1,42 @@
+{% raw %}
+{% extends "mfa/webauthn/base.html" %}
+{% load humanize %}
+
+{% block mfa_content %}
+  <div class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+    <div>
+      <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Manage passkeys</h1>
+      <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Review, rename, or remove passkeys for your your account.</p>
+    </div>
+    <a href="{% url 'mfa_index' %}" class="text-sm font-medium text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-400 dark:hover:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-300">Back to passkeys</a>
+  </div>
+
+  {% if authenticators %}
+    <div class="mt-8 overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700">
+      <ul class="divide-y divide-gray-200 dark:divide-gray-700">
+        {% for authenticator in authenticators %}
+          <li class="flex flex-col gap-4 bg-white p-4 dark:bg-gray-900 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p class="font-medium text-gray-900 dark:text-gray-100">{{ authenticator }}</p>
+              <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                Added {{ authenticator.created_at|date:"SHORT_DATE_FORMAT" }}{% if authenticator.last_used_at %}; last used {{ authenticator.last_used_at|naturaltime }}{% else %}; not used yet{% endif %}.
+              </p>
+            </div>
+            <div class="flex gap-2">
+              <a href="{% url 'mfa_edit_webauthn' pk=authenticator.pk %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Edit</a>
+              <a href="{% url 'mfa_remove_webauthn' pk=authenticator.pk %}" class="inline-flex justify-center rounded-md border border-red-300 bg-white px-3 py-2 text-sm font-medium text-red-700 shadow-sm hover:bg-red-50 dark:border-red-900/70 dark:bg-gray-900 dark:text-red-300 dark:hover:bg-red-950/40">Remove</a>
+            </div>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
+  {% else %}
+    <p class="mt-8 rounded-xl border border-gray-200 bg-gray-50 p-5 text-sm text-gray-600 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-300">No passkeys have been added yet.</p>
+  {% endif %}
+
+  <div class="mt-6">
+    <a href="{% url 'mfa_add_webauthn' %}" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Add passkey</a>
+  </div>
+{% endblock mfa_content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/base.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/base.html
@@ -1,0 +1,8 @@
+{% raw %}
+{% extends "mfa/base_manage.html" %}
+
+{% block meta %}
+<title>Passkeys · the app</title>
+{% endblock meta %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/edit_form.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/edit_form.html
@@ -1,0 +1,24 @@
+{% raw %}
+{% extends "mfa/webauthn/base.html" %}
+{% load widget_tweaks %}
+
+{% block mfa_content %}
+  <h1 class="text-2xl font-bold tracking-tight text-gray-900 dark:text-gray-100">Rename passkey</h1>
+  <p class="mt-2 text-sm leading-6 text-gray-600 dark:text-gray-300">Give this passkey a name you will recognize later.</p>
+
+  <form class="mt-8 space-y-6" method="post" action="{% url 'mfa_edit_webauthn' pk=object.pk %}">
+    {% csrf_token %}
+    {{ form.non_field_errors|safe }}
+    <div>
+      {{ form.name.errors|safe }}
+      <label for="{{ form.name.id_for_label }}" class="block text-sm font-medium text-gray-900 dark:text-gray-100">Passkey name</label>
+      {% render_field form.name class="mt-2 block w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 placeholder-gray-500 shadow-sm focus:border-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:outline-none focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 sm:text-sm" %}
+    </div>
+    <div class="flex flex-col gap-3 sm:flex-row">
+      <button type="submit" class="inline-flex justify-center rounded-md bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 focus:outline-none focus:ring-2 focus:ring-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">Save</button>
+      <a href="{% url 'mfa_list_webauthn' %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">Cancel</a>
+    </div>
+  </form>
+{% endblock mfa_content %}
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/snippets/login_script.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/snippets/login_script.html
@@ -1,0 +1,56 @@
+{% raw %}
+{% include "mfa/webauthn/snippets/scripts.html" %}
+<form id="mfa_login" action="{% url 'mfa_login_webauthn' %}" method="post">
+    {% csrf_token %}
+    {{ redirect_field }}
+    <input type="hidden" name="credential" id="mfa_credential">
+</form>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var loginBtn = document.getElementById('{{ button_id|default:"passkey_login" }}');
+    var form = document.getElementById('mfa_login');
+    var credentialInput = document.getElementById('mfa_credential');
+
+    if (!loginBtn || !form || !credentialInput || !window.webauthnJSON) {
+      return;
+    }
+
+    loginBtn.addEventListener('click', async function (event) {
+      event.preventDefault();
+      try {
+        var response = await fetch(form.action, {
+          method: 'GET',
+          headers: {
+            'Accept': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest'
+          },
+          credentials: 'same-origin'
+        });
+        if (!response.ok) {
+          throw new Error('Unable to fetch passkey data from server.');
+        }
+
+        var data = await response.json();
+        var requestOptions = data.request_options || (data.data && data.data.request_options);
+        if (!requestOptions || !requestOptions.publicKey) {
+          throw new Error('Passkey login did not receive valid browser options from the server.');
+        }
+
+        var credential = await window.webauthnJSON.get(requestOptions);
+        credentialInput.value = JSON.stringify(credential);
+        form.submit();
+      } catch (exception) {
+        var errorEvent = new CustomEvent('allauth.error', {
+          detail: { tags: ['mfa', 'webauthn', 'login'], exception: exception },
+          cancelable: true
+        });
+        document.dispatchEvent(errorEvent);
+        if (!errorEvent.defaultPrevented) {
+          console.error(exception);
+        }
+      }
+    });
+  });
+</script>
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/snippets/scripts.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/mfa/webauthn/snippets/scripts.html
@@ -1,0 +1,20 @@
+{% raw %}
+{% load i18n static %}
+<noscript>
+  <p class="mt-4 rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 dark:border-yellow-900/60 dark:bg-yellow-950/30 dark:text-yellow-200">{% translate "Passkey setup requires JavaScript." %}</p>
+</noscript>
+<script src="{% static 'mfa/js/webauthn-json.js' %}"></script>
+<script src="{% static 'mfa/js/webauthn.js' %}"></script>
+<script src="{% static 'account/js/onload.js' %}"></script>
+<script>
+  document.addEventListener('allauth.error', function (event) {
+    event.preventDefault();
+    var message = event.detail && event.detail.exception && event.detail.exception.message
+      ? event.detail.exception.message
+      : 'Passkey setup could not start. Make sure you are using HTTPS and a browser/device that supports passkeys.';
+    window.alert(message);
+    console.error(event.detail && event.detail.exception ? event.detail.exception : event);
+  });
+</script>
+
+{% endraw %}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/user-settings.html
@@ -9,6 +9,27 @@
 {{ "{% block content %}" }}
   <div class="container px-4 py-8 mx-auto max-w-3xl bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 lg:min-w-0 md:pt-10 lg:flex-1">
     {{ '{% include "components/confirm-email.html" with email_verified=email_verified %}' }}
+    <section class="p-6 mt-6 mb-8 rounded-lg border border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-800/50" aria-labelledby="passkey-settings-heading">
+      <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h3 id="passkey-settings-heading" class="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">Passkeys</h3>
+          <p class="mt-1 text-sm text-gray-600 dark:text-gray-300">
+            Add a passkey after account creation to sign in faster without typing your password.
+            {{ "{% if passkey_count %}" }}You have {% raw %}{{ passkey_count }}{% endraw %} passkey{% raw %}{{ passkey_count|pluralize }}{% endraw %} set up.{{ "{% endif %}" }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-2 sm:flex-row">
+          <a href="{% raw %}{% url 'mfa_add_webauthn' %}{% endraw %}" class="inline-flex justify-center rounded-md bg-{{ cookiecutter.project_main_color }}-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-{{ cookiecutter.project_main_color }}-700 focus:outline-none focus:ring-2 focus:ring-{{ cookiecutter.project_main_color }}-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900">
+            Add passkey
+          </a>
+          {{ "{% if passkey_count %}" }}
+            <a href="{% raw %}{% url 'mfa_list_webauthn' %}{% endraw %}" class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-900 shadow-sm hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800">
+              Manage passkeys
+            </a>
+          {{ "{% endif %}" }}
+        </div>
+      </div>
+    </section>
     <div class="p-4 border-t border-b border-gray-200 dark:border-gray-700 sm:p-6 lg:p-8 xl:border-t-0">
       <div class="flex justify-between items-center">
         <h1 class="flex-1 pt-2 text-xl font-medium">Settings</h1>

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -297,15 +297,14 @@ LOGIN_REDIRECT_URL = "home"
 ACCOUNT_LOGOUT_REDIRECT_URL = "landing"
 
 ACCOUNT_USER_MODEL_USERNAME_FIELD = "username"
-ACCOUNT_LOGIN_METHODS = {'username'}
-ACCOUNT_SIGNUP_FIELDS = ["email*", "username*", "password1*", "password2*"]
-ACCOUNT_LOGIN_METHODS = {"username"}
+ACCOUNT_LOGIN_METHODS = {"email"}
+ACCOUNT_SIGNUP_FIELDS = ["email*", "password1*"]
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_SESSION_REMEMBER = True
 ACCOUNT_EMAIL_SUBJECT_PREFIX = ""
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
-ACCOUNT_EMAIL_VERIFICATION = "mandatory"
-ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = True
+ACCOUNT_EMAIL_VERIFICATION = "optional"
+ACCOUNT_EMAIL_VERIFICATION_BY_CODE_ENABLED = False
 ALLOW_SIGNUPS = env.bool("ALLOW_SIGNUPS", default=True)
 ACCOUNT_FORMS = {
     "signup": "apps.core.forms.CustomSignUpForm",
@@ -318,7 +317,7 @@ if ENVIRONMENT != "dev":
 # Passkey (WebAuthn) auth support via django-allauth MFA.
 MFA_SUPPORTED_TYPES = ["webauthn"]
 MFA_PASSKEY_LOGIN_ENABLED = True
-MFA_PASSKEY_SIGNUP_ENABLED = True
+MFA_PASSKEY_SIGNUP_ENABLED = False
 # Local dev uses http://localhost, so allow insecure origin only in debug.
 MFA_WEBAUTHN_ALLOW_INSECURE_ORIGIN = DEBUG
 
@@ -341,10 +340,16 @@ if GITHUB_CLIENT_ID != "":
 MAILGUN_API_KEY = env("MAILGUN_API_KEY", default="")
 ANYMAIL = {
     "MAILGUN_API_KEY": MAILGUN_API_KEY,
-    "MAILGUN_SENDER_DOMAIN": "mg.{{ cookiecutter.project_slug }}.app",
+    "MAILGUN_SENDER_DOMAIN": env("MAILGUN_SENDER_DOMAIN", default="mg.{{ cookiecutter.project_slug }}.app"),
 }
-DEFAULT_FROM_EMAIL = "{{ cookiecutter.author_name }} from {{ cookiecutter.project_name }} <hello@{{ cookiecutter.project_slug }}.app>"
-SERVER_EMAIL = "{{ cookiecutter.project_name }} Errors <error@{{ cookiecutter.project_slug }}.app>"
+DEFAULT_FROM_EMAIL = env(
+    "DEFAULT_FROM_EMAIL",
+    default="{{ cookiecutter.author_name }} from {{ cookiecutter.project_name }} <hello@{{ cookiecutter.project_slug }}.app>",
+)
+SERVER_EMAIL = env(
+    "SERVER_EMAIL",
+    default="{{ cookiecutter.project_name }} Errors <error@{{ cookiecutter.project_slug }}.app>",
+)
 
 if DEBUG:
     EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"


### PR DESCRIPTION
## Summary
- upstream FileBridge auth UX learnings into generated projects: email-only login with no password confirmation, non-blocking email verification, passkey setup from settings instead of passkey signup
- add styled allauth account/MFA/passkey templates plus a safer WebAuthn login launcher that validates JSON `request_options.publicKey` before calling `webauthnJSON.get(...)`
- harden deploy startup with DB wait loop, `migrate --noinput`, and `exec`; keep the final-image entrypoint executable
- generate fresh initial migrations in `post_gen_project.py` after cookiecutter option cleanup instead of committing static initial migration files to the template
- make Mailgun sender/default-from/server-email configurable and document the env vars

## Greptile comments addressed
- fixed settings-page null/DoesNotExist handling for users without an allauth `EmailAddress`
- made confirmation resend POST-only
- removed redundant build-stage `chmod +x` from both deployment Dockerfiles
- replaced hardcoded `green-*` classes in the new raw-wrapped allauth/MFA templates with `project_main_color` rendering

## Validation
- `uv run pytest tests/test_cookiecutter_template.py -q` — 22 passed
- `uv run pytest -q` — 22 passed
- generated sample project: `DJANGO_SETTINGS_MODULE=test_sqlite_settings uv run python manage.py check`
- generated sample project: `PYTHONPATH=. DJANGO_SETTINGS_MODULE=test_sqlite_settings uv run pytest apps/pages/tests.py apps/core/tests/test_signup_gating.py apps/core/tests/test_email_delivery.py -q` — 28 passed
- generated sample project: `DJANGO_SETTINGS_MODULE=test_sqlite_settings uv run python manage.py makemigrations --check --dry-run`

## Notes
- Please do not merge yet; waiting for review/approval as requested.
- Generated-project `ruff check .` still reports pre-existing template-wide lint findings unrelated to this patch; CI does not currently run that gate.
