### PR TITLE
Add optional Chatwoot support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Optional `use_chatwoot` generator flag for Chatwoot support chat, including self-hosted/cloud setup docs, HMAC identity validation support, and runtime-off defaults.
 - Post-generation hook now creates fresh initial migrations after cookiecutter option cleanup, avoiding static template migrations while keeping generated projects deploy-ready.
 - Generated projects now include styled django-allauth email/passkey/MFA account templates, post-registration passkey setup links, and hardened WebAuthn login JavaScript.
 - Generated projects now include an `ALLOW_SIGNUPS` environment flag (default `True`) to pause new email/social registrations while keeping existing user logins available.

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,6 +8,7 @@
   "author_url": "",
   "project_main_color": "green",
   "use_posthog": "y",
+  "use_chatwoot": "n",
   "use_buttondown": "y",
   "use_s3": "y",
   "use_stripe": "y",

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -57,6 +57,24 @@ def remove_stripe_files():
         print("Removed pricing template")
 
 
+def remove_chatwoot_files():
+    """Remove Chatwoot-related files if use_chatwoot is 'n'."""
+    chatwoot_template_path = Path("frontend/templates/components/chatwoot.html")
+    if chatwoot_template_path.exists():
+        chatwoot_template_path.unlink()
+        print("Removed Chatwoot template")
+
+    chatwoot_tests_path = Path("apps/core/tests/test_chatwoot_context.py")
+    if chatwoot_tests_path.exists():
+        chatwoot_tests_path.unlink()
+        print("Removed Chatwoot context tests")
+
+    chatwoot_docs_path = Path("apps/docs/content/deployment/chatwoot.md")
+    if chatwoot_docs_path.exists():
+        chatwoot_docs_path.unlink()
+        print("Removed Chatwoot deployment guide")
+
+
 def remove_ci_workflow():
     """Remove CI workflow if use_ci is 'n'."""
     ci_workflow_path = Path(".github/workflows/ci.yml")
@@ -124,6 +142,7 @@ def main():
     generate_blog = "{{ cookiecutter.generate_blog }}"
     generate_docs = "{{ cookiecutter.generate_docs }}"
     use_stripe = "{{ cookiecutter.use_stripe }}"
+    use_chatwoot = "{{ cookiecutter.use_chatwoot }}"
     use_ci = "{{ cookiecutter.use_ci }}"
 
     if generate_blog != "y":
@@ -142,6 +161,11 @@ def main():
         print("Stripe disabled, removing Stripe-related files...")
         remove_stripe_files()
         print("Stripe cleanup complete!")
+
+    if use_chatwoot != "y":
+        print("Chatwoot disabled, removing Chatwoot-related files...")
+        remove_chatwoot_files()
+        print("Chatwoot cleanup complete!")
 
     if use_ci != "y":
         print("CI disabled, removing CI workflow...")

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -21,6 +21,7 @@ def _generate(tmp_path: Path, **extra_context: str) -> Path:
         "project_main_color": "green",
         # defaults (can be overridden per test)
         "use_posthog": "n",
+        "use_chatwoot": "n",
         "use_buttondown": "n",
         "use_s3": "n",
         "use_stripe": "n",
@@ -389,6 +390,42 @@ def test_use_posthog_toggles_posthog_snippet(tmp_path: Path) -> None:
 
     _assert_contains(enabled_base, "posthog.init")
     _assert_not_contains(disabled_base, "posthog.init")
+
+
+def test_use_chatwoot_toggles_support_chat(tmp_path: Path) -> None:
+    enabled = _generate(tmp_path, use_chatwoot="y", generate_docs="y")
+    disabled = _generate(tmp_path, use_chatwoot="n", generate_docs="y")
+
+    enabled_settings = enabled / "test_project" / "settings.py"
+    enabled_context = enabled / "apps" / "core" / "context_processors.py"
+    enabled_app_base = enabled / "frontend" / "templates" / "base_app.html"
+    enabled_landing_base = enabled / "frontend" / "templates" / "base_landing.html"
+    enabled_env = enabled / ".env.example"
+    enabled_docs = enabled / "apps" / "docs" / "content" / "deployment" / "chatwoot.md"
+    enabled_navigation = enabled / "apps" / "docs" / "navigation.yaml"
+
+    _assert_contains(enabled_settings, "CHATWOOT_BASE_URL = env(")
+    _assert_contains(enabled_settings, "apps.core.context_processors.chatwoot_config")
+    _assert_contains(enabled_context, "def chatwoot_config")
+    _assert_contains(enabled_app_base, "components/chatwoot.html")
+    _assert_contains(enabled_landing_base, "components/chatwoot.html")
+    _assert_not_contains(enabled_app_base, "components/feedback.html")
+    _assert_not_contains(enabled_landing_base, "components/feedback.html")
+    _assert_contains(enabled_env, "CHATWOOT_BASE_URL=")
+    _assert_contains(enabled_env, "CHATWOOT_WEBSITE_TOKEN=")
+    _assert_contains(enabled_env, "CHATWOOT_HMAC_SECRET=")
+    _assert_contains(enabled_docs, "Self-hosted Chatwoot setup")
+    _assert_contains(enabled_navigation, "- chatwoot")
+    assert (enabled / "apps" / "core" / "tests" / "test_chatwoot_context.py").exists()
+
+    _assert_not_contains(disabled / "test_project" / "settings.py", "CHATWOOT_BASE_URL")
+    _assert_not_contains(disabled / "apps" / "core" / "context_processors.py", "chatwoot_config")
+    _assert_not_contains(disabled / "frontend" / "templates" / "base_app.html", "components/chatwoot.html")
+    _assert_contains(disabled / "frontend" / "templates" / "base_app.html", "components/feedback.html")
+    _assert_not_contains(disabled / ".env.example", "CHATWOOT_WEBSITE_TOKEN")
+    assert not (disabled / "frontend" / "templates" / "components" / "chatwoot.html").exists()
+    assert not (disabled / "apps" / "core" / "tests" / "test_chatwoot_context.py").exists()
+    assert not (disabled / "apps" / "docs" / "content" / "deployment" / "chatwoot.md").exists()
 
 
 def test_use_sentry_includes_observability_defaults(tmp_path: Path) -> None:

--- a/{{ cookiecutter.project_slug }}/.env.example
+++ b/{{ cookiecutter.project_slug }}/.env.example
@@ -99,3 +99,12 @@ SENTRY_MAX_BREADCRUMBS=100
 {% if cookiecutter.use_posthog == 'y' -%}
 POSTHOG_API_KEY=
 {%- endif %}
+{% if cookiecutter.use_chatwoot == 'y' -%}
+# Chatwoot support chat. Leave either base URL or token empty to disable the widget.
+# Self-hosted example: https://chatwoot.yourdomain.com
+# Chatwoot Cloud example: https://app.chatwoot.com
+CHATWOOT_BASE_URL=
+CHATWOOT_WEBSITE_TOKEN=
+# Optional but recommended: enable Identity Validation in the Chatwoot Website inbox and paste the HMAC token here.
+CHATWOOT_HMAC_SECRET=
+{%- endif %}

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -147,6 +147,29 @@ You'd still need to make sure .env has correct values.
    - The frontend dev container now uses Node 24 and the backend waits for `frontend/build/manifest.json` before booting, so the first page load should not race the asset pipeline.
 5. Run `make restart-worker` just in case, it sometimes has troubles connecting to REDIS on first deployment.
 
+{% if cookiecutter.use_chatwoot == 'y' -%}
+## Chatwoot Support Chat
+
+This project includes optional Chatwoot support chat. It is disabled until both runtime env vars are set on the Django web app:
+
+```env
+CHATWOOT_BASE_URL=
+CHATWOOT_WEBSITE_TOKEN=
+```
+
+For self-hosted Chatwoot, use your own base URL, for example `https://chatwoot.yourdomain.com`. For Chatwoot Cloud, use the base URL from Chatwoot's snippet, commonly `https://app.chatwoot.com`.
+
+To get the token: in Chatwoot go to **Settings → Inboxes → Add Inbox → Website**, finish setup, then copy `websiteToken` from the install snippet.
+
+Recommended for authenticated apps: enable **Identity Validation** for that Website inbox and set:
+
+```env
+CHATWOOT_HMAC_SECRET=
+```
+
+Gotchas: add these env vars to the Django web app, not only workers; restart/redeploy after env changes; paste the full token, not a shortened `abc…xyz` display value. See `apps/docs/content/deployment/chatwoot.md` for the full checklist.
+
+{% endif -%}
 ### CI (optional)
 
 If you generated the project with `use_ci = y`, it includes a GitHub Actions workflow at `.github/workflows/ci.yml` that runs on pull requests.

--- a/{{ cookiecutter.project_slug }}/apps/core/context_processors.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/context_processors.py
@@ -1,3 +1,8 @@
+{% if cookiecutter.use_chatwoot == 'y' -%}
+import hashlib
+import hmac
+{% endif %}
+
 from allauth.socialaccount.models import SocialApp
 from django.conf import settings
 
@@ -32,6 +37,49 @@ def posthog_api_key(request):
 {% if cookiecutter.use_mjml == 'y' -%}
 def mjml_url(request):
     return {"mjml_url": settings.MJML_URL}
+{% endif %}
+
+{% if cookiecutter.use_chatwoot == 'y' -%}
+def _chatwoot_identifier_hash(identifier):
+    if not settings.CHATWOOT_HMAC_SECRET:
+        return ""
+
+    return hmac.new(
+        settings.CHATWOOT_HMAC_SECRET.encode("utf-8"),
+        str(identifier).encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def chatwoot_config(request):
+    base_url = settings.CHATWOOT_BASE_URL.rstrip("/")
+    website_token = settings.CHATWOOT_WEBSITE_TOKEN
+    if not base_url or not website_token:
+        return {"chatwoot": {"enabled": False}}
+
+    config = {
+        "enabled": True,
+        "base_url": base_url,
+        "website_token": website_token,
+        "user": None,
+    }
+
+    user = request.user
+    if user.is_authenticated:
+        identifier = str(user.pk)
+        user_config = {
+            "identifier": identifier,
+            "email": user.email,
+            "name": user.get_full_name() or user.email,
+        }
+
+        identifier_hash = _chatwoot_identifier_hash(identifier)
+        if identifier_hash:
+            user_config["identifier_hash"] = identifier_hash
+
+        config["user"] = user_config
+
+    return {"chatwoot": config}
 {% endif %}
 
 def available_social_providers(request):

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_chatwoot_context.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_chatwoot_context.py
@@ -1,0 +1,95 @@
+import hmac
+from hashlib import sha256
+from types import SimpleNamespace
+
+from django.test import RequestFactory, override_settings
+
+from apps.core.context_processors import chatwoot_config
+
+
+@override_settings(CHATWOOT_BASE_URL="", CHATWOOT_WEBSITE_TOKEN="")
+def test_chatwoot_context_disabled_without_config():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(is_authenticated=False)
+
+    assert chatwoot_config(request) == {"chatwoot": {"enabled": False}}
+
+
+@override_settings(CHATWOOT_BASE_URL="", CHATWOOT_WEBSITE_TOKEN="website-token")
+def test_chatwoot_context_disabled_without_base_url():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(is_authenticated=False)
+
+    assert chatwoot_config(request) == {"chatwoot": {"enabled": False}}
+
+
+@override_settings(CHATWOOT_BASE_URL="https://chatwoot.example.com", CHATWOOT_WEBSITE_TOKEN="")
+def test_chatwoot_context_disabled_without_website_token():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(is_authenticated=False)
+
+    assert chatwoot_config(request) == {"chatwoot": {"enabled": False}}
+
+
+@override_settings(
+    CHATWOOT_BASE_URL="https://chatwoot.example.com/",
+    CHATWOOT_WEBSITE_TOKEN="website-token",
+    CHATWOOT_HMAC_SECRET="",
+)
+def test_chatwoot_context_enables_anonymous_widget():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(is_authenticated=False)
+
+    assert chatwoot_config(request) == {
+        "chatwoot": {
+            "enabled": True,
+            "base_url": "https://chatwoot.example.com",
+            "website_token": "website-token",
+            "user": None,
+        }
+    }
+
+
+@override_settings(
+    CHATWOOT_BASE_URL="https://chatwoot.example.com",
+    CHATWOOT_WEBSITE_TOKEN="website-token",
+    CHATWOOT_HMAC_SECRET="",
+)
+def test_chatwoot_context_identifies_authenticated_user_without_hmac():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(
+        is_authenticated=True,
+        pk=42,
+        email="ada@example.com",
+        get_full_name=lambda: "Ada Lovelace",
+    )
+
+    assert chatwoot_config(request)["chatwoot"]["user"] == {
+        "identifier": "42",
+        "email": "ada@example.com",
+        "name": "Ada Lovelace",
+    }
+
+
+@override_settings(
+    CHATWOOT_BASE_URL="https://app.chatwoot.com",
+    CHATWOOT_WEBSITE_TOKEN="website-token",
+    CHATWOOT_HMAC_SECRET="hmac-secret",
+)
+def test_chatwoot_context_identifies_authenticated_user_with_hmac():
+    request = RequestFactory().get("/")
+    request.user = SimpleNamespace(
+        is_authenticated=True,
+        pk=42,
+        email="ada@example.com",
+        get_full_name=lambda: "",
+    )
+
+    expected_hash = hmac.new(b"hmac-secret", b"42", sha256).hexdigest()
+
+    assert chatwoot_config(request)["chatwoot"]["user"] == {
+        "identifier": "42",
+        "email": "ada@example.com",
+        "name": "ada@example.com",
+        "identifier_hash": expected_hash,
+    }

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/chatwoot.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/chatwoot.md
@@ -1,0 +1,102 @@
+---
+title: Chatwoot Support Chat
+description: Configure the optional Chatwoot website widget for support, feedback, bug reports, and feature requests.
+keywords: {{ cookiecutter.project_name }}, Chatwoot, support chat, feedback, customer support
+author: {{ cookiecutter.author_name }}
+---
+
+Chatwoot support chat is included because this project was generated with `use_chatwoot = y`.
+
+The feature is still runtime-opt-in: the widget only appears when both `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` are set in the Django web app environment.
+
+## What gets installed
+
+- A Django context processor: `apps.core.context_processors.chatwoot_config`
+- A template include: `frontend/templates/components/chatwoot.html`
+- Includes in the app and landing base templates
+- Optional authenticated-user identification via `window.$chatwoot.setUser(...)`
+- Optional HMAC Identity Validation via `CHATWOOT_HMAC_SECRET`
+
+## Self-hosted Chatwoot setup
+
+Use this path if you run Chatwoot yourself, for example on CapRover.
+
+1. Open your Chatwoot dashboard, for example `https://chatwoot.yourdomain.com`.
+2. Go to **Settings → Inboxes**.
+3. Click **Add Inbox** / **New Inbox**.
+4. Choose **Website**.
+5. Name the inbox after this app, for example `{{ cookiecutter.project_name }}`.
+6. Add your production site domain when Chatwoot asks for the website domain.
+7. Finish setup.
+8. Open the inbox settings/configuration and copy the `websiteToken` from the install snippet.
+
+Set:
+
+```env
+CHATWOOT_BASE_URL=https://chatwoot.yourdomain.com
+CHATWOOT_WEBSITE_TOKEN=<websiteToken from the Website inbox>
+```
+
+Do not paste the full `<script>...</script>` snippet into Django templates. This starter already includes the widget loader; it only needs the base URL and token.
+
+## Chatwoot Cloud setup
+
+Use the same Website inbox flow in Chatwoot Cloud.
+
+Set:
+
+```env
+CHATWOOT_BASE_URL=https://app.chatwoot.com
+CHATWOOT_WEBSITE_TOKEN=<websiteToken from the Website inbox>
+```
+
+If your Chatwoot Cloud workspace uses a region-specific or custom domain, use the base URL from the snippet Chatwoot gives you.
+
+## Identity Validation / HMAC
+
+For authenticated SaaS apps, enable Identity Validation so users cannot impersonate each other in Chatwoot conversations.
+
+1. In Chatwoot, open **Settings → Inboxes → your Website inbox**.
+2. Go to **Settings → Configuration → Identity Validation**.
+3. Enable/copy the HMAC token.
+4. Set it as:
+
+```env
+CHATWOOT_HMAC_SECRET=<identity validation HMAC token>
+```
+
+This app signs the authenticated Django user's primary key as the Chatwoot identifier. It also sends their email and display name.
+
+If you enable Identity Validation in Chatwoot but forget `CHATWOOT_HMAC_SECRET`, the widget may load but authenticated identity can fail. Either set the correct secret or disable Identity Validation in Chatwoot.
+
+## Deployment checklist
+
+1. Add env vars to the Django web app/container:
+   - `CHATWOOT_BASE_URL`
+   - `CHATWOOT_WEBSITE_TOKEN`
+   - `CHATWOOT_HMAC_SECRET` if Identity Validation is enabled
+2. Restart/redeploy the web app after changing env vars.
+3. Open a page that uses `base_app.html` or `base_landing.html`.
+4. Confirm the Chatwoot bubble appears in the bottom-right corner.
+5. For logged-in users, start a conversation and confirm Chatwoot shows the user's email/name.
+
+## Common gotchas
+
+- **Wrong app/container:** Adding env vars only to a worker process will not show the widget. They must be present on the process rendering Django pages.
+- **No restart after env changes:** Django reads settings at process startup. Restart/redeploy after changing env vars.
+- **Token ellipsis:** Do not paste a shortened token like `abc…xyz`. Paste the full `websiteToken` from Chatwoot.
+- **Base URL mismatch:** Use the same base URL shown in Chatwoot's snippet. Self-hosted examples look like `https://chatwoot.yourdomain.com`; Chatwoot Cloud commonly uses `https://app.chatwoot.com`.
+- **Identity Validation mismatch:** If Chatwoot has Identity Validation enabled, `CHATWOOT_HMAC_SECRET` must match that exact inbox's token.
+- **Ad blockers / browser privacy tools:** Some extensions block chat widgets. Check the browser console/network tab for blocked `sdk.js` requests.
+- **CSP/security headers:** If you add a strict Content Security Policy later, allow scripts/connections/frames for your Chatwoot base URL.
+
+## Disabling Chatwoot
+
+Unset either value and restart the web app:
+
+```env
+CHATWOOT_BASE_URL=
+CHATWOOT_WEBSITE_TOKEN=
+```
+
+The template include stays installed, but it renders nothing unless both values are configured.

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/environment-variables.md
@@ -150,6 +150,34 @@ These variables enhance functionality but aren't required:
 - Leave empty to disable PostHog
 
 {% endif -%}
+{% if cookiecutter.use_chatwoot == 'y' -%}
+### Chatwoot (Support Chat)
+
+**CHATWOOT_BASE_URL**
+- Base URL for your Chatwoot instance.
+- Self-hosted example: `https://chatwoot.yourdomain.com`.
+- Chatwoot Cloud example: `https://app.chatwoot.com`.
+- Leave empty to disable the support chat widget.
+- Do not include a trailing slash; the app also strips it defensively.
+
+**CHATWOOT_WEBSITE_TOKEN**
+- Website inbox token from Chatwoot.
+- In Chatwoot: **Settings → Inboxes → Add Inbox → Website**, finish setup, then copy the `websiteToken` from the install snippet or inbox configuration.
+- Leave empty to disable the support chat widget.
+
+**CHATWOOT_HMAC_SECRET**
+- Optional but recommended for authenticated SaaS apps.
+- In Chatwoot: **Settings → Inboxes → your Website inbox → Settings → Configuration → Identity Validation** and copy the HMAC token.
+- Used to sign the authenticated user's identifier before calling `window.$chatwoot.setUser(...)`, which helps prevent customer impersonation.
+- Leave empty if Identity Validation is disabled in Chatwoot.
+
+Gotchas:
+- Add these variables to the web app/container that serves Django pages. Worker-only apps will not make the browser widget appear.
+- Restart/redeploy the web app after changing environment variables so Django reloads settings.
+- If Chatwoot Identity Validation is enabled but `CHATWOOT_HMAC_SECRET` is missing or wrong, the widget can load but user identity can fail.
+- If the bubble does not appear, confirm both `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` are non-empty in the running web process and check the browser console/network tab for blocked `sdk.js` requests.
+
+{% endif -%}
 {% if cookiecutter.use_buttondown == 'y' -%}
 ### Buttondown (Email Newsletter)
 

--- a/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
+++ b/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
@@ -37,5 +37,9 @@ navigation:
   deployment:
     - render-deployment
     - docker-compose-deployment
+    - environment-variables
+    {% if cookiecutter.use_chatwoot == 'y' -%}
+    - chatwoot
+    {% endif %}
 
   # Any categories not listed here will appear after these, in alphabetical order

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -78,10 +78,12 @@
     {{ "{% include 'components/messages.html' with messages=messages %}" }}
   {{ "{% endblock default_messages %}" }}
 
+  {% if cookiecutter.use_chatwoot != 'y' -%}
   <!-- Include the feedback component -->
   {{ "{% if user.is_authenticated %}" }}
     {{ "{% include 'components/feedback.html' %}" }}
   {{ "{% endif %}" }}
+  {% endif %}
 
   <div class="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
     <header class="sticky left-0 top-3 z-10">
@@ -263,6 +265,10 @@
     }
     </script>
   {{ "{% endblock schema %}" }}
+
+  {% if cookiecutter.use_chatwoot == 'y' -%}
+  {{ "{% include 'components/chatwoot.html' %}" }}
+  {% endif %}
 
 </body>
 

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -81,10 +81,12 @@
     {{ "{% include 'components/messages.html' with messages=messages %}" }}
   {{ "{% endblock default_messages %}" }}
 
+  {% if cookiecutter.use_chatwoot != 'y' -%}
   <!-- Include the feedback component -->
   {{ "{% if user.is_authenticated %}" }}
     {{ "{% include 'components/feedback.html' %}" }}
   {{ "{% endif %}" }}
+  {% endif %}
 
   <div class="min-h-screen bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
     <header class="sticky left-0 top-3 z-10">
@@ -269,6 +271,10 @@
     }
     </script>
   {{ "{% endblock schema %}" }}
+
+  {% if cookiecutter.use_chatwoot == 'y' -%}
+  {{ "{% include 'components/chatwoot.html' %}" }}
+  {% endif %}
 
 </body>
 

--- a/{{ cookiecutter.project_slug }}/frontend/templates/components/chatwoot.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/components/chatwoot.html
@@ -1,0 +1,47 @@
+{{ "{% if chatwoot.enabled %}" }}
+  {{ "{{ chatwoot|json_script:'chatwoot-config' }}" }}
+  <script>
+    (function () {
+      var configElement = document.getElementById("chatwoot-config");
+      if (!configElement) {
+        return;
+      }
+
+      var config = JSON.parse(configElement.textContent);
+      window.chatwootSettings = {
+        position: "right",
+        type: "standard",
+        launcherTitle: "",
+      };
+
+      var script = document.createElement("script");
+      var firstScript = document.getElementsByTagName("script")[0];
+      script.src = config.base_url + "/packs/js/sdk.js";
+      script.async = true;
+      firstScript.parentNode.insertBefore(script, firstScript);
+
+      script.onload = function () {
+        window.chatwootSDK.run({
+          websiteToken: config.website_token,
+          baseUrl: config.base_url,
+        });
+      };
+
+      window.addEventListener("chatwoot:ready", function () {
+        if (!config.user || !window.$chatwoot) {
+          return;
+        }
+
+        var userAttributes = {
+          email: config.user.email,
+          name: config.user.name,
+        };
+        if (config.user.identifier_hash) {
+          userAttributes.identifier_hash = config.user.identifier_hash;
+        }
+
+        window.$chatwoot.setUser(config.user.identifier, userAttributes);
+      });
+    })();
+  </script>
+{{ "{% endif %}" }}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -162,6 +162,9 @@ TEMPLATES = [
                 {% if cookiecutter.use_posthog == 'y' -%}
                 "apps.core.context_processors.posthog_api_key",
                 {% endif %}
+                {% if cookiecutter.use_chatwoot == 'y' -%}
+                "apps.core.context_processors.chatwoot_config",
+                {% endif %}
                 {% if cookiecutter.use_mjml == 'y' -%}
                 "apps.core.context_processors.mjml_url",
                 {% endif %}
@@ -550,6 +553,12 @@ if SENTRY_DSN and ENVIRONMENT == "prod":
 
 {% if cookiecutter.use_posthog == 'y' -%}
 POSTHOG_API_KEY = env("POSTHOG_API_KEY", default="")
+{% endif %}
+
+{% if cookiecutter.use_chatwoot == 'y' -%}
+CHATWOOT_BASE_URL = env("CHATWOOT_BASE_URL", default="")
+CHATWOOT_WEBSITE_TOKEN = env("CHATWOOT_WEBSITE_TOKEN", default="")
+CHATWOOT_HMAC_SECRET = env("CHATWOOT_HMAC_SECRET", default="")
 {% endif %}
 
 {% if cookiecutter.use_buttondown == 'y' -%}


### PR DESCRIPTION
## Summary
- Add a new `use_chatwoot` Cookiecutter option, defaulting to `n` so generated projects stay unchanged/off by default.
- When enabled, include a Chatwoot context processor, widget template include, runtime env settings, HMAC identity validation support, and generated-project tests.
- Remove the legacy floating feedback component from base templates only when Chatwoot is enabled, so users do not get two competing feedback channels.
- Add self-hosted-first and Chatwoot Cloud setup docs, env examples, deployment checklist, and gotchas learned from the FileBridge rollout.

## Validation
- `uv run --with ruff ruff check hooks/post_gen_project.py tests/test_cookiecutter_template.py --fix && uv run --with ruff ruff check hooks/post_gen_project.py tests/test_cookiecutter_template.py`
- `uv run --group test pytest tests/test_cookiecutter_template.py::test_use_chatwoot_toggles_support_chat -q`
- `uv run --group test pytest -q`
- Generated Chatwoot-enabled smoke project and ran: `uv run pytest apps/core/tests/test_chatwoot_context.py -q`
- Generated Chatwoot-enabled smoke project and ran: `uv run python manage.py check` (passes with expected warning that `frontend/build` does not exist before frontend build)

## Notes
- Runtime behavior stays opt-in even when generated with `use_chatwoot = y`: the widget renders only if both `CHATWOOT_BASE_URL` and `CHATWOOT_WEBSITE_TOKEN` are present.
- Self-hosted default path is documented first; Chatwoot Cloud uses the same env shape with `https://app.chatwoot.com` or the base URL from the Chatwoot snippet.
