### PR TITLE
test: add cookiecutter CLI generation smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- CI now includes a real Cookiecutter CLI smoke test that renders a project end-to-end and fails on non-zero generation exits.
 - Optional `use_chatwoot` generator flag for Chatwoot support chat, including self-hosted/cloud setup docs, HMAC identity validation support, and runtime-off defaults.
 - Post-generation hook now creates fresh initial migrations after cookiecutter option cleanup, avoiding static template migrations while keeping generated projects deploy-ready.
 - Generated projects now include styled django-allauth email/passkey/MFA account templates, post-registration passkey setup links, and hardened WebAuthn login JavaScript.

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 import uuid
 from pathlib import Path
 
@@ -62,6 +64,62 @@ def _assert_contains(path: Path, needle: str) -> None:
 def _assert_not_contains(path: Path, needle: str) -> None:
     content = _read_text(path)
     assert needle not in content, f"Expected not to find {needle!r} in {path}"
+
+
+def test_cookiecutter_cli_generates_project_successfully(tmp_path: Path) -> None:
+    """Smoke-test the real Cookiecutter CLI so CI catches end-to-end generation failures."""
+    template_dir = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "cookiecutter-cli-output"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "cookiecutter",
+            "--no-input",
+            "--output-dir",
+            str(output_dir),
+            str(template_dir),
+            "project_name=CLI Smoke Project",
+            "repo_url=https://example.com/test/cli-smoke-project",
+            "project_description=CLI smoke generation",
+            "author_name=Ada Lovelace",
+            "author_email=ada@example.com",
+            "author_url=",
+            "project_main_color=green",
+            "use_posthog=n",
+            "use_chatwoot=n",
+            "use_buttondown=n",
+            "use_s3=n",
+            "use_stripe=n",
+            "use_sentry=n",
+            "generate_blog=y",
+            "generate_docs=y",
+            "use_mjml=n",
+            "use_ai=n",
+            "use_logfire=n",
+            "use_healthchecks=n",
+            "use_ci=y",
+        ],
+        cwd=template_dir,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+
+    assert result.returncode == 0, (
+        "Cookiecutter CLI generation failed\n"
+        f"exit code: {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+    project_dir = output_dir / "cli_smoke_project"
+    assert project_dir.exists()
+    assert (project_dir / "manage.py").exists()
+    assert (project_dir / "pyproject.toml").exists()
 
 
 def test_generate_default_structure(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add a pytest smoke test that invokes the real Cookiecutter CLI via `python -m cookiecutter`.
- Generate a project end-to-end with explicit non-interactive context and fail loudly on any non-zero CLI exit.
- Assert the generated project directory and core files exist.
- Update the changelog under `[Unreleased]`.

## Validation
- `uv run --group test pytest` → 24 passed in 441.82s

## Flags/context tested
- `use_posthog=n`
- `use_chatwoot=n`
- `use_buttondown=n`
- `use_s3=n`
- `use_stripe=n`
- `use_sentry=n`
- `generate_blog=y`
- `generate_docs=y`
- `use_mjml=n`
- `use_ai=n`
- `use_logfire=n`
- `use_healthchecks=n`
- `use_ci=y`
