### PR TITLE
feat: add generated design system docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Generated projects now include a generic, Google DESIGN.md-style `DESIGN.md` design-system source of truth plus README/docs guidance for human and AI-agent contributors.
 - CI now includes a real Cookiecutter CLI smoke test that renders a project end-to-end and fails on non-zero generation exits.
 - Optional `use_chatwoot` generator flag for Chatwoot support chat, including self-hosted/cloud setup docs, HMAC identity validation support, and runtime-off defaults.
 - Post-generation hook now creates fresh initial migrations after cookiecutter option cleanup, avoiding static template migrations while keeping generated projects deploy-ready.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Important: in generated projects, run `python manage.py makemigrations` (without
 - ✅ **StimulusJS** for interactivity
 - ✅ **Webpack** setup (assets pipeline)
 - ✅ SEO-friendly templates (meta tags, JSON-LD schema, OG images)
+- ✅ Root `DESIGN.md` based on Google Labs Code's DESIGN.md format for tool-neutral human/AI design guidance
 
 ### Pages & content
 - ✅ Landing + pricing + auth pages + sitemap
@@ -73,6 +74,7 @@ Important: in generated projects, run `python manage.py makemigrations` (without
 - ❓ Posthog
 
 ### AI
+- ✅ Tool-neutral `DESIGN.md` design source of truth for humans and AI coding agents
 - ✅ Cursor Rules
 - ❓ `pydanticai` for agents in-app
 

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -131,6 +131,7 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     # sanity: core entrypoints exist
     assert (project_dir / "manage.py").exists()
     assert (project_dir / "pyproject.toml").exists()
+    assert (project_dir / "DESIGN.md").exists()
     assert (project_dir / "frontend" / "templates").exists()
 
     # new feature: account deletion flow
@@ -154,9 +155,16 @@ def test_generate_default_structure(tmp_path: Path) -> None:
         'def send_transactional_email(',
     )
 
+    # generated design-system docs should be present and agent/tool neutral
+    _assert_contains(project_dir / "DESIGN.md", "Google Labs Code")
+    _assert_contains(project_dir / "DESIGN.md", "agent-neutral")
+    _assert_contains(project_dir / "README.md", "npx @google/design.md lint DESIGN.md")
+
     # optional apps on by default in this test helper
     assert (project_dir / "apps" / "blog").exists()
     assert (project_dir / "apps" / "docs").exists()
+    assert (project_dir / "apps" / "docs" / "content" / "getting-started" / "design-system.md").exists()
+    _assert_contains(project_dir / "apps" / "docs" / "navigation.yaml", "- design-system")
     assert not (
         Path(__file__).resolve().parents[1]
         / "{{ cookiecutter.project_slug }}"
@@ -332,6 +340,8 @@ def test_generate_without_docs_removes_docs_app_and_templates(tmp_path: Path) ->
 
     assert not (project_dir / "apps" / "docs").exists()
     assert not (project_dir / "frontend" / "templates" / "docs").exists()
+    assert (project_dir / "DESIGN.md").exists()
+    _assert_contains(project_dir / "README.md", "DESIGN.md")
 
 
 def test_generate_without_stripe_removes_stripe_files(tmp_path: Path) -> None:

--- a/{{ cookiecutter.project_slug }}/DESIGN.md
+++ b/{{ cookiecutter.project_slug }}/DESIGN.md
@@ -87,6 +87,7 @@ rounded:
 spacing:
   xs: 4px
   sm: 8px
+  control: 12px
   md: 16px
   lg: 24px
   xl: 32px
@@ -101,7 +102,7 @@ components:
     textColor: "{colors.text-inverse}"
     typography: "{typography.label-md}"
     rounded: "{rounded.full}"
-    padding: 12px
+    padding: "{spacing.control}"
   button-primary-hover:
     backgroundColor: "{colors.primary-hover}"
     textColor: "{colors.text-inverse}"
@@ -110,13 +111,13 @@ components:
     textColor: "{colors.secondary}"
     typography: "{typography.label-md}"
     rounded: "{rounded.full}"
-    padding: 12px
+    padding: "{spacing.control}"
   button-danger:
     backgroundColor: "{colors.danger}"
     textColor: "{colors.text-inverse}"
     typography: "{typography.label-md}"
     rounded: "{rounded.full}"
-    padding: 12px
+    padding: "{spacing.control}"
   card:
     backgroundColor: "{colors.surface}"
     textColor: "{colors.text}"
@@ -138,7 +139,7 @@ components:
     backgroundColor: "{colors.surface}"
     textColor: "{colors.text}"
     rounded: "{rounded.md}"
-    padding: 12px
+    padding: "{spacing.control}"
   badge-success:
     backgroundColor: "{colors.primary-soft}"
     textColor: "{colors.success}"

--- a/{{ cookiecutter.project_slug }}/DESIGN.md
+++ b/{{ cookiecutter.project_slug }}/DESIGN.md
@@ -1,0 +1,257 @@
+---
+version: alpha
+name: "{{ cookiecutter.project_name }}"
+description: "Default SaaS design system for {{ cookiecutter.project_name }}. Replace these tokens and notes as the product identity matures."
+colors:
+  primary: "#15803D"
+  primary-hover: "#166534"
+  primary-soft: "#DCFCE7"
+  secondary: "#0F172A"
+  secondary-soft: "#E2E8F0"
+  accent: "#2563EB"
+  neutral: "#F8FAFC"
+  surface: "#FFFFFF"
+  surface-muted: "#F1F5F9"
+  surface-dark: "#020617"
+  border: "#E2E8F0"
+  border-dark: "#1E293B"
+  text: "#0F172A"
+  text-muted: "#475569"
+  text-inverse: "#FFFFFF"
+  success: "#166534"
+  warning: "#F59E0B"
+  danger: "#DC2626"
+typography:
+  headline-display:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 60px
+    fontWeight: 800
+    lineHeight: 1
+    letterSpacing: -0.04em
+  headline-lg:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 48px
+    fontWeight: 800
+    lineHeight: 1.05
+    letterSpacing: -0.035em
+  headline-md:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 30px
+    fontWeight: 750
+    lineHeight: 1.15
+    letterSpacing: -0.025em
+  headline-sm:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 24px
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: -0.015em
+  body-lg:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 18px
+    fontWeight: 400
+    lineHeight: 1.65
+  body-md:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.65
+  body-sm:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 14px
+    fontWeight: 400
+    lineHeight: 1.55
+  label-md:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 14px
+    fontWeight: 650
+    lineHeight: 1.3
+  label-caps:
+    fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
+    fontSize: 12px
+    fontWeight: 700
+    lineHeight: 1
+    letterSpacing: 0.14em
+  code-sm:
+    fontFamily: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace
+    fontSize: 13px
+    fontWeight: 500
+    lineHeight: 1.6
+rounded:
+  none: 0px
+  sm: 6px
+  md: 10px
+  lg: 14px
+  xl: 20px
+  full: 9999px
+spacing:
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 24px
+  xl: 32px
+  2xl: 48px
+  3xl: 64px
+  section-y: 96px
+  page-x: 24px
+  container: 1200px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.text-inverse}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.full}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.primary-hover}"
+    textColor: "{colors.text-inverse}"
+  button-secondary:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.secondary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.full}"
+    padding: 12px
+  button-danger:
+    backgroundColor: "{colors.danger}"
+    textColor: "{colors.text-inverse}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.full}"
+    padding: 12px
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  card-muted:
+    backgroundColor: "{colors.surface-muted}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.xl}"
+    padding: 24px
+  app-shell:
+    backgroundColor: "{colors.neutral}"
+    textColor: "{colors.text}"
+  nav:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.full}"
+  input:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text}"
+    rounded: "{rounded.md}"
+    padding: 12px
+  badge-success:
+    backgroundColor: "{colors.primary-soft}"
+    textColor: "{colors.success}"
+    typography: "{typography.label-caps}"
+    rounded: "{rounded.full}"
+    padding: 8px
+  badge-warning:
+    backgroundColor: "{colors.warning}"
+    textColor: "{colors.surface-dark}"
+    typography: "{typography.label-caps}"
+    rounded: "{rounded.full}"
+    padding: 8px
+  badge-neutral:
+    backgroundColor: "{colors.secondary-soft}"
+    textColor: "{colors.secondary}"
+    typography: "{typography.label-caps}"
+    rounded: "{rounded.full}"
+    padding: 8px
+  link:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.accent}"
+    typography: "{typography.body-md}"
+  divider-light:
+    backgroundColor: "{colors.border}"
+    height: 1px
+  divider-dark:
+    backgroundColor: "{colors.border-dark}"
+    height: 1px
+  muted-copy:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.text-muted}"
+    typography: "{typography.body-sm}"
+---
+
+# {{ cookiecutter.project_name }} Design System
+
+## Overview
+
+This file is the project-level design source of truth for humans and AI coding agents. It follows the public Google Labs Code [`DESIGN.md`](https://github.com/google-labs-code/design.md) alpha format: YAML design tokens first, then markdown guidance explaining how to apply them.
+
+The default style is intentionally generic for a modern Django SaaS product: clean, trustworthy, accessible, and easy to customize after generation. Treat this as a starting point, not a permanent brand identity.
+
+When the product direction is clearer, update this file before making broad UI changes. Keep the tokens and prose aligned so different agents and tools produce consistent interfaces.
+
+## Colors
+
+The default palette uses practical SaaS neutrals with one confident primary color.
+
+- **Primary (#15803D):** Main action color for CTAs, selected states, success-adjacent highlights, and the most important conversion path.
+- **Secondary (#0F172A):** Deep slate for headlines, app chrome, and high-contrast UI surfaces.
+- **Accent (#2563EB):** Secondary action/link color. Use it for navigation emphasis and informational affordances, not the main conversion path.
+- **Neutral/Surface (#F8FAFC / #FFFFFF / #F1F5F9):** Light surfaces for pages, cards, forms, dashboards, and marketing sections.
+- **Semantic colors:** Green for success, amber for warning, red for destructive or error states.
+
+If your generated project needs a different brand, start by changing `primary`, `primary-hover`, `primary-soft`, and `accent`, then review button, badge, and link components.
+
+## Typography
+
+Use a system sans-serif stack for speed, reliability, and low setup friction. Add a brand font later only if it improves the product enough to justify the dependency.
+
+- **Headlines:** Bold, slightly tight tracking for landing pages, docs intros, and major empty states.
+- **Body:** 16px default with generous line height for readable forms, settings pages, docs, and dashboards.
+- **Labels:** Medium-weight labels for form controls and action buttons.
+- **Caps labels:** Use sparingly for section eyebrows, small status badges, and metadata.
+- **Code:** Monospace for API examples, environment variables, commands, tokens, and identifiers.
+
+## Layout
+
+Use simple responsive layouts that work well for server-rendered Django pages.
+
+- Keep page content inside a centered max-width container (`1200px`) with `24px` mobile-safe horizontal padding.
+- Use generous vertical rhythm on marketing pages and tighter spacing in authenticated app screens.
+- Prefer boring, predictable grids: single column on mobile, 2-column feature areas, 3-column card groups when content is symmetrical.
+- Forms should be narrow enough to scan comfortably. Dashboards can use wider containers, but avoid dense data walls without hierarchy.
+- Design empty, loading, error, and success states as first-class UI, not afterthoughts.
+
+## Elevation & Depth
+
+Depth should come from borders, spacing, and subtle shadows.
+
+- Default cards use light backgrounds, clear borders, and rounded corners.
+- Use shadows only for overlays, menus, modals, and important hover states.
+- Dark surfaces are reserved for headers, footers, code examples, and high-contrast hero sections.
+- Avoid heavy glassmorphism, noisy gradients, and decorative effects that make forms or tables harder to read.
+
+## Shapes
+
+The default shape language is friendly but restrained.
+
+- Use pill buttons for primary actions and navigation CTAs.
+- Use `10px`–`20px` radius for inputs, cards, panels, and modal containers.
+- Use full-radius badges for status labels.
+- Keep radius choices consistent within each screen; inconsistency makes generated products feel stitched together.
+
+## Components
+
+- **Primary button:** Primary background, white text, pill radius, medium-bold label. Use for the single most important action in a section.
+- **Secondary button:** White or muted background, slate text, border when needed. Use for navigation, cancel, and lower-priority actions.
+- **Danger button:** Red background, white text. Use only for irreversible destructive actions and pair with confirmation UI.
+- **Cards:** White/muted surfaces with rounded corners and borders. Keep one clear purpose per card.
+- **Forms:** Visible labels, clear helper/error text, high-contrast focus rings, and full-width controls on mobile.
+- **Navigation:** Simple top nav with clear product name, primary links, auth/account actions, and accessible mobile behavior.
+- **Tables/lists:** Prioritize scanability: sticky or repeated context where needed, muted metadata, and explicit empty states.
+- **Docs/code blocks:** Monospace code, copyable commands when possible, and examples that match the generated project structure.
+
+## Do's and Don'ts
+
+- Do update this file when the brand, UI conventions, or component rules change.
+- Do keep YAML tokens and markdown descriptions consistent.
+- Do preserve WCAG AA contrast for text, buttons, alerts, and form states.
+- Do design for both anonymous marketing pages and authenticated SaaS app screens.
+- Do keep guidance agent-neutral: useful to humans, Codex, Claude Code, Cursor, and any future coding tool.
+- Don't hard-code maintainer names, domains, or one project's positioning into reusable UI guidance.
+- Don't introduce a new font, color, radius, or shadow style for a single screen without updating the design system.
+- Don't make AI-agent instructions vendor-specific; use plain project conventions and file paths.
+- Don't let generated pages depend on remote design assets unless the project explicitly adds them.

--- a/{{ cookiecutter.project_slug }}/DESIGN.md
+++ b/{{ cookiecutter.project_slug }}/DESIGN.md
@@ -37,7 +37,7 @@ typography:
   headline-md:
     fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
     fontSize: 30px
-    fontWeight: 750
+    fontWeight: 700
     lineHeight: 1.15
     letterSpacing: -0.025em
   headline-sm:
@@ -64,7 +64,7 @@ typography:
   label-md:
     fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
     fontSize: 14px
-    fontWeight: 650
+    fontWeight: 600
     lineHeight: 1.3
   label-caps:
     fontFamily: Inter, ui-sans-serif, system-ui, sans-serif
@@ -122,12 +122,12 @@ components:
     backgroundColor: "{colors.surface}"
     textColor: "{colors.text}"
     rounded: "{rounded.xl}"
-    padding: 24px
+    padding: "{spacing.lg}"
   card-muted:
     backgroundColor: "{colors.surface-muted}"
     textColor: "{colors.text}"
     rounded: "{rounded.xl}"
-    padding: 24px
+    padding: "{spacing.lg}"
   app-shell:
     backgroundColor: "{colors.neutral}"
     textColor: "{colors.text}"
@@ -145,19 +145,19 @@ components:
     textColor: "{colors.success}"
     typography: "{typography.label-caps}"
     rounded: "{rounded.full}"
-    padding: 8px
+    padding: "{spacing.sm}"
   badge-warning:
     backgroundColor: "{colors.warning}"
     textColor: "{colors.surface-dark}"
     typography: "{typography.label-caps}"
     rounded: "{rounded.full}"
-    padding: 8px
+    padding: "{spacing.sm}"
   badge-neutral:
     backgroundColor: "{colors.secondary-soft}"
     textColor: "{colors.secondary}"
     typography: "{typography.label-caps}"
     rounded: "{rounded.full}"
-    padding: 8px
+    padding: "{spacing.sm}"
   link:
     backgroundColor: "{colors.surface}"
     textColor: "{colors.accent}"

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -14,9 +14,17 @@
 
 - Add info about your project here
 
-### Theme
+### Theme and design system
 
 This template includes a dark/light mode toggle in the navbar. The preference is stored in `localStorage` and applied early to avoid a flash of incorrect theme.
+
+This project also includes a root-level `DESIGN.md` file based on the public Google Labs Code [`DESIGN.md`](https://github.com/google-labs-code/design.md) alpha format. It gives humans and AI coding agents a shared, tool-neutral design source of truth: colors, typography, spacing, radii, component guidance, and practical do/don't rules.
+
+Treat the generated `DESIGN.md` as a generic SaaS baseline. Update it when your brand or UI direction changes, then keep templates/components aligned with it. You can validate it with:
+
+```bash
+npx @google/design.md lint DESIGN.md
+```
 
 ### Project structure: `/apps`
 
@@ -51,6 +59,7 @@ These endpoints use superuser API auth by default and are intended as a starter 
 
 - [Overview](#overview)
 - [TOC](#toc)
+- [Theme and design system](#theme-and-design-system)
 - [Deployment](#deployment)
   - [Render](#render)
   - [Docker Compose](#docker-compose)

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/getting-started/design-system.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/getting-started/design-system.md
@@ -1,0 +1,52 @@
+# Design system
+
+Generated projects include a root-level `DESIGN.md` file.
+
+`DESIGN.md` is a human- and agent-readable design source of truth. It follows the public Google Labs Code [`DESIGN.md`](https://github.com/google-labs-code/design.md) alpha format: YAML design tokens at the top, followed by markdown guidance explaining how to apply those tokens.
+
+## Why it exists
+
+This starter is often edited by humans and AI coding agents. A checked-in `DESIGN.md` gives every contributor the same baseline for:
+
+- colors and semantic roles
+- typography scale
+- spacing and radius choices
+- common component styling
+- layout patterns
+- practical do/don't guardrails
+
+The default file is intentionally generic for most SaaS projects. It should be updated once your product has a clearer brand or UI direction.
+
+## How to use it
+
+Before making broad UI changes, read `DESIGN.md` and keep new templates/components consistent with it.
+
+When the design direction changes:
+
+1. Update the YAML tokens first.
+2. Update the markdown sections so the prose matches the tokens.
+3. Run the linter:
+
+```bash
+npx @google/design.md lint DESIGN.md
+```
+
+4. Then update templates, Tailwind classes, screenshots, or docs that rely on the old system.
+
+## Agent-neutral workflow
+
+Do not make this file specific to one AI tool. Keep it useful for humans and any coding agent by describing project conventions, token names, component rules, and file paths in plain language.
+
+Good guidance:
+
+- "Use `primary` for the single most important action per screen."
+- "Forms should include labels, helper/error text, and visible focus states."
+- "Update `DESIGN.md` before broad UI redesigns."
+
+Avoid guidance like:
+
+- "Cursor should..."
+- "Claude must..."
+- "Codex only..."
+
+The goal is a portable design contract that survives across tools.

--- a/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
+++ b/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
@@ -29,6 +29,7 @@
 navigation:
   getting-started:
     - introduction
+    - design-system
     # Any pages not listed here will appear after these, in alphabetical order
 
   features:


### PR DESCRIPTION
## Summary
- add a generated root `DESIGN.md` using Google Labs Code's DESIGN.md alpha format
- document where it comes from and how to update/lint it in the generated README and generated docs app
- keep guidance generic/tool-neutral for humans and any AI coding agent, not Cursor/Codex/Claude-specific
- add template regression coverage for default generation and `generate_docs = n`
- update root README and changelog

## Validation
- `npx @google/design.md lint '{{ cookiecutter.project_slug }}/DESIGN.md'` → 0 errors, 0 warnings
- `uv run --group test pytest` → 24 passed
- generated smoke project with `SKIP_POST_GEN_MIGRATIONS=1`, then `npx @google/design.md lint <generated>/DESIGN.md` → 0 errors, 0 warnings
