### PR TITLE
Add optional MCP server support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -19,5 +19,6 @@
   "use_ai": "y",
   "use_logfire": "y",
   "use_healthchecks": "y",
+  "use_mcp": "n",
   "use_ci": "y"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -75,6 +75,19 @@ def remove_chatwoot_files():
         print("Removed Chatwoot deployment guide")
 
 
+def remove_mcp_files():
+    """Remove MCP-related files if use_mcp is 'n'."""
+    mcp_app_path = Path("apps/mcp_server")
+    if mcp_app_path.exists():
+        shutil.rmtree(mcp_app_path)
+        print("Removed MCP server app")
+
+    mcp_docs_path = Path("apps/docs/content/features/mcp.md")
+    if mcp_docs_path.exists():
+        mcp_docs_path.unlink()
+        print("Removed MCP feature docs")
+
+
 def remove_ci_workflow():
     """Remove CI workflow if use_ci is 'n'."""
     ci_workflow_path = Path(".github/workflows/ci.yml")
@@ -143,6 +156,7 @@ def main():
     generate_docs = "{{ cookiecutter.generate_docs }}"
     use_stripe = "{{ cookiecutter.use_stripe }}"
     use_chatwoot = "{{ cookiecutter.use_chatwoot }}"
+    use_mcp = "{{ cookiecutter.use_mcp }}"
     use_ci = "{{ cookiecutter.use_ci }}"
 
     if generate_blog != "y":
@@ -166,6 +180,11 @@ def main():
         print("Chatwoot disabled, removing Chatwoot-related files...")
         remove_chatwoot_files()
         print("Chatwoot cleanup complete!")
+
+    if use_mcp != "y":
+        print("MCP disabled, removing MCP-related files...")
+        remove_mcp_files()
+        print("MCP cleanup complete!")
 
     if use_ci != "y":
         print("CI disabled, removing CI workflow...")

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -34,6 +34,7 @@ def _generate(tmp_path: Path, **extra_context: str) -> Path:
         "use_ai": "n",
         "use_logfire": "n",
         "use_healthchecks": "n",
+        "use_mcp": "n",
         "use_ci": "y",
     }
     context.update(extra_context)
@@ -100,6 +101,7 @@ def test_cookiecutter_cli_generates_project_successfully(tmp_path: Path) -> None
             "use_ai=n",
             "use_logfire=n",
             "use_healthchecks=n",
+            "use_mcp=n",
             "use_ci=y",
         ],
         cwd=template_dir,
@@ -291,6 +293,50 @@ def test_generated_mfa_templates_use_configured_project_colour(tmp_path: Path) -
     )
 
 
+
+def test_generated_project_includes_user_info_api_endpoint(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path, use_mcp="n")
+
+    api_views = project_dir / "apps" / "api" / "views.py"
+    api_schemas = project_dir / "apps" / "api" / "schemas.py"
+    api_services = project_dir / "apps" / "api" / "services.py"
+    api_tests = project_dir / "apps" / "api" / "tests.py"
+
+    _assert_contains(api_views, '"/user"')
+    _assert_contains(api_views, "auth=api_key_auth")
+    _assert_contains(api_views, "serialize_user_info(request.auth)")
+    _assert_not_contains(api_schemas, "is_superuser")
+    _assert_contains(api_schemas, "class UserInfoOut")
+    _assert_contains(api_services, "def serialize_user_info")
+    _assert_contains(api_tests, "test_get_user_info_returns_safe_profile_data")
+
+
+def test_use_mcp_default_removes_mcp_server_but_keeps_user_api(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path)
+
+    assert not (project_dir / "apps" / "mcp_server").exists()
+    assert not (project_dir / "apps" / "docs" / "content" / "features" / "mcp.md").exists()
+    _assert_not_contains(project_dir / "pyproject.toml", "fastmcp")
+    _assert_not_contains(project_dir / "deployment" / "entrypoint.sh", "uvicorn_worker")
+    _assert_contains(project_dir / "apps" / "api" / "views.py", '"/user"')
+
+
+def test_use_mcp_includes_hosted_server_skill_and_docs(tmp_path: Path) -> None:
+    project_dir = _generate(tmp_path, use_mcp="y")
+
+    assert (project_dir / "apps" / "mcp_server" / "server.py").exists()
+    assert (project_dir / "apps" / "mcp_server" / "tests" / "test_server.py").exists()
+    _assert_contains(project_dir / "pyproject.toml", "fastmcp")
+    _assert_contains(project_dir / "pyproject.toml", "uvicorn-worker")
+    _assert_contains(project_dir / "test_project" / "asgi.py", 'Mount("/mcp"')
+    _assert_contains(project_dir / "test_project" / "settings.py", "apps.mcp_server.apps.McpServerConfig")
+    _assert_contains(project_dir / "deployment" / "entrypoint.sh", "uvicorn_worker.UvicornWorker")
+    _assert_contains(project_dir / "render.yaml", "uvicorn_worker.UvicornWorker")
+    _assert_contains(project_dir / "apps" / "core" / "urls.py", "SKILL.md")
+    _assert_contains(project_dir / "apps" / "core" / "views.py", "def skill_markdown")
+    _assert_contains(project_dir / "apps" / "docs" / "content" / "features" / "mcp.md", "get_user_info")
+    _assert_contains(project_dir / "README.md", "Hosted MCP server")
+
 def test_generate_without_blog_removes_blog_app_and_templates(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path, generate_blog="n")
 
@@ -411,6 +457,8 @@ def test_generate_without_ci_removes_ci_workflow(tmp_path: Path) -> None:
         ("use_ai", "pydantic-ai"),
         ("use_ai", "pgvector"),
         ("use_logfire", "logfire"),
+        ("use_mcp", "fastmcp"),
+        ("use_mcp", "uvicorn-worker"),
         ("use_posthog", "posthog"),
         ("use_sentry", "sentry-sdk"),
     ],

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -33,8 +33,42 @@ This project keeps Django apps inside the `/apps` directory. This is both for hu
 - `apps/core`: main app functionality (shared domain logic, base models, services, etc.)
 - `apps/docs`: user-facing documentation
 - `apps/api`: all API needs (Django Ninja routers, schemas, API-specific logic)
+{% if cookiecutter.use_mcp == 'y' -%}
+- `apps/mcp_server`: hosted MCP tools for agent integrations
+{% endif %}
 - `apps/pages`: landing/marketing pages (pricing, TOS, privacy policy, etc.)
 - `apps/blog`: user-facing blog
+
+
+### Agent API endpoint
+
+All generated projects include `GET /api/user`, which returns safe account/profile details for the authenticated API key. This is intentionally small but useful as the first "agent can authenticate and know who it is acting for" endpoint.
+
+{% if cookiecutter.use_mcp == 'y' -%}
+### Hosted MCP server
+
+This project includes a hosted MCP server at `/mcp/`, plus a ready-to-copy agent skill at `/SKILL.md`. The first tool is `get_user_info`, backed by the same serializer as `GET /api/user`.
+
+Supported MCP auth methods:
+
+- `Authorization: Bearer <api_key>`
+- `X-API-Key: <api_key>`
+- `?api_key=<api_key>` on the MCP URL
+- `api_key` tool argument
+
+The REST user endpoint supports the Bearer token, `X-API-Key`, and `?api_key=` methods.
+
+Give an agent this starter prompt:
+
+```text
+Add {{ cookiecutter.project_name }} MCP support to this repo.
+
+Use MCP URL: <production-url>/mcp/
+Use the user's {{ cookiecutter.project_name }} API key from an environment variable. Do not hardcode, log, or commit the key.
+First verify the connection by calling the get_user_info MCP tool or GET <production-url>/api/user with the API key, then add the smallest useful integration for this codebase.
+Document how future agents should configure the MCP server locally.
+```
+{% endif %}
 
 {% if cookiecutter.generate_blog == 'y' -%}
 ### Blog management API endpoints (admin)
@@ -113,7 +147,11 @@ How you are going to expose the backend container is up to you. I usually do it 
 Not recommended due to not being too safe for production and not being tested by me.
 
 If you are not into Docker or Render and just wanto to run this via regular commands you will need to have 5 processes running:
+{% if cookiecutter.use_mcp == 'y' -%}
+- `python manage.py collectstatic --noinput && python manage.py migrate && gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker`
+{% else -%}
 - `python manage.py collectstatic --noinput && python manage.py migrate && gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2`
+{% endif %}
 - `python manage.py qcluster`
 - `npm install && npm run start`
 - `postgres`

--- a/{{ cookiecutter.project_slug }}/apps/api/auth.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/auth.py
@@ -1,5 +1,5 @@
 from django.http import HttpRequest
-from ninja.security import APIKeyQuery
+from ninja.security import APIKeyHeader, APIKeyQuery, HttpBearer
 
 from apps.core.models import Profile
 
@@ -8,19 +8,32 @@ from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_sl
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
 
 
+def _get_profile_for_api_key(key: str) -> Profile | None:
+    logger.info("[Django Ninja Auth] API key request")
+    try:
+        return Profile.objects.select_related("user").get(key=key)
+    except Profile.DoesNotExist:
+        logger.warning("[Django Ninja Auth] Invalid API key")
+        return None
+
+
 class APIKeyAuth(APIKeyQuery):
     param_name = "api_key"
 
     def authenticate(self, request: HttpRequest, key: str) -> Profile | None:
-        logger.info(
-            "[Django Ninja Auth] API Request with key",
-            key=key,
-        )
-        try:
-            return Profile.objects.get(key=key)
-        except Profile.DoesNotExist:
-            logger.warning("[Django Ninja Auth] Invalid API key", key=key)
-            return None
+        return _get_profile_for_api_key(key)
+
+
+class APIKeyHeaderAuth(APIKeyHeader):
+    param_name = "X-API-Key"
+
+    def authenticate(self, request: HttpRequest, key: str) -> Profile | None:
+        return _get_profile_for_api_key(key)
+
+
+class BearerAPIKeyAuth(HttpBearer):
+    def authenticate(self, request: HttpRequest, token: str) -> Profile | None:
+        return _get_profile_for_api_key(token)
 
 
 class SessionAuth:
@@ -48,7 +61,7 @@ class SuperuserAPIKeyAuth(APIKeyQuery):
 
     def authenticate(self, request: HttpRequest, key: str) -> Profile | None:
         try:
-            profile = Profile.objects.get(key=key)
+            profile = Profile.objects.select_related("user").get(key=key)
             if profile.user.is_superuser:
                 return profile
             logger.warning(
@@ -57,10 +70,10 @@ class SuperuserAPIKeyAuth(APIKeyQuery):
             )
             return None
         except Profile.DoesNotExist:
-            logger.warning("[Django Ninja Auth] Profile does not exist", key=key)
+            logger.warning("[Django Ninja Auth] Profile does not exist")
             return None
 
 
-api_key_auth = APIKeyAuth()
+api_key_auth = [APIKeyAuth(), APIKeyHeaderAuth(), BearerAPIKeyAuth()]
 session_auth = SessionAuth()
 superuser_api_auth = SuperuserAPIKeyAuth()

--- a/{{ cookiecutter.project_slug }}/apps/api/schemas.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/schemas.py
@@ -1,5 +1,7 @@
-from ninja import Schema
+from datetime import datetime
 from typing import Optional
+
+from ninja import Schema
 
 {% if cookiecutter.generate_blog == 'y' %}
 from apps.blog.choices import BlogPostStatus
@@ -71,3 +73,20 @@ class ProfileSettingsOut(Schema):
 
 class UserSettingsOut(Schema):
     profile: ProfileSettingsOut
+
+
+class UserProfileOut(Schema):
+    id: int
+    state: str
+    has_active_subscription: bool
+
+
+class UserInfoOut(Schema):
+    id: int
+    email: str
+    username: str
+    first_name: str
+    last_name: str
+    full_name: str
+    date_joined: datetime
+    profile: UserProfileOut

--- a/{{ cookiecutter.project_slug }}/apps/api/services.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/services.py
@@ -1,0 +1,20 @@
+from apps.core.models import Profile
+
+
+def serialize_user_info(profile: Profile) -> dict:
+    """Return safe user/profile details for API and MCP consumers."""
+    user = profile.user
+    return {
+        "id": user.id,
+        "email": user.email,
+        "username": user.username,
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "full_name": user.get_full_name(),
+        "date_joined": user.date_joined,
+        "profile": {
+            "id": profile.id,
+            "state": profile.state,
+            "has_active_subscription": {% if cookiecutter.use_stripe == 'y' -%}profile.has_active_subscription{% else -%}False{% endif %},
+        },
+    }

--- a/{{ cookiecutter.project_slug }}/apps/api/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/tests.py
@@ -185,3 +185,88 @@ class PlaceholderApiTests(SimpleTestCase):
     def test_placeholder(self):
         assert True
 {% endif %}
+
+class UserInfoApiUnitTests(SimpleTestCase):
+    def test_get_user_info_returns_safe_profile_data(self):
+        from apps.api.views import get_user_info
+
+        user = SimpleNamespace(
+            id=7,
+            email="ada@example.com",
+            username="ada",
+            first_name="Ada",
+            last_name="Lovelace",
+            date_joined="2026-05-14T00:00:00Z",
+            get_full_name=lambda: "Ada Lovelace",
+        )
+        profile = SimpleNamespace(
+            id=11,
+            user=user,
+            state="signed_up",
+            {% if cookiecutter.use_stripe == 'y' -%}
+            has_active_subscription=False,
+            {% endif %}
+        )
+        request = HttpRequest()
+        request.auth = profile
+
+        response = get_user_info(request)
+
+        assert response["email"] == "ada@example.com"
+        assert response["full_name"] == "Ada Lovelace"
+        assert response["profile"] == {
+            "id": 11,
+            "state": "signed_up",
+            "has_active_subscription": False,
+        }
+        assert "key" not in response
+
+
+def test_api_key_auth_returns_profile_for_valid_key():
+    from apps.api.auth import APIKeyAuth, APIKeyHeaderAuth, BearerAPIKeyAuth
+    from apps.core.models import Profile
+
+    profile = SimpleNamespace(id=11)
+
+    for auth_class in [APIKeyAuth, APIKeyHeaderAuth, BearerAPIKeyAuth]:
+        with patch("apps.api.auth.Profile.objects") as objects:
+            objects.select_related.return_value.get.return_value = profile
+            response = auth_class().authenticate(HttpRequest(), "secret-key")
+
+        assert response is profile
+        objects.select_related.assert_called_once_with("user")
+        objects.select_related.return_value.get.assert_called_once_with(key="secret-key")
+
+    with patch("apps.api.auth.Profile.objects") as objects:
+        objects.select_related.return_value.get.side_effect = Profile.DoesNotExist
+        response = APIKeyAuth().authenticate(HttpRequest(), "bad-key")
+
+    assert response is None
+
+
+def test_superuser_api_key_auth_eager_loads_user_and_requires_superuser():
+    from apps.api.auth import SuperuserAPIKeyAuth
+    from apps.core.models import Profile
+
+    superuser_profile = SimpleNamespace(id=11, user=SimpleNamespace(id=21, is_superuser=True))
+    regular_profile = SimpleNamespace(id=12, user=SimpleNamespace(id=22, is_superuser=False))
+
+    with patch("apps.api.auth.Profile.objects") as objects:
+        objects.select_related.return_value.get.return_value = superuser_profile
+        response = SuperuserAPIKeyAuth().authenticate(HttpRequest(), "secret-key")
+
+    assert response is superuser_profile
+    objects.select_related.assert_called_once_with("user")
+    objects.select_related.return_value.get.assert_called_once_with(key="secret-key")
+
+    with patch("apps.api.auth.Profile.objects") as objects:
+        objects.select_related.return_value.get.return_value = regular_profile
+        response = SuperuserAPIKeyAuth().authenticate(HttpRequest(), "regular-key")
+
+    assert response is None
+
+    with patch("apps.api.auth.Profile.objects") as objects:
+        objects.select_related.return_value.get.side_effect = Profile.DoesNotExist
+        response = SuperuserAPIKeyAuth().authenticate(HttpRequest(), "bad-key")
+
+    assert response is None

--- a/{{ cookiecutter.project_slug }}/apps/api/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/api/views.py
@@ -4,7 +4,8 @@ from django.core.cache import cache
 from ninja import NinjaAPI
 from ninja.errors import HttpError
 
-from apps.api.auth import session_auth, superuser_api_auth
+from apps.api.auth import api_key_auth, session_auth, superuser_api_auth
+from apps.api.services import serialize_user_info
 from apps.core.models import Feedback
 {% if cookiecutter.generate_blog == 'y' -%}
 from apps.blog.models import BlogPost
@@ -22,6 +23,7 @@ from apps.api.schemas import (
     BlogPostDetailOut,
     {% endif -%}
     ProfileSettingsOut,
+    UserInfoOut,
     UserSettingsOut,
 )
 
@@ -306,6 +308,16 @@ def publish_internal_blog_post(request: HttpRequest, blog_post_id: int):
         "blog_post": _serialize_blog_post(blog_post),
     }
 {% endif %}
+
+@api.get(
+    "/user",
+    response=UserInfoOut,
+    auth=api_key_auth,
+    tags=["user"],
+)
+def get_user_info(request: HttpRequest):
+    """Return safe profile and account details for the authenticated API key."""
+    return serialize_user_info(request.auth)
 
 @api.get(
     "/user/settings",

--- a/{{ cookiecutter.project_slug }}/apps/core/urls.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/urls.py
@@ -3,6 +3,9 @@ from django.urls import path
 from apps.core import views
 
 urlpatterns = [
+    {% if cookiecutter.use_mcp == 'y' -%}
+    path("SKILL.md", views.skill_markdown, name="agent_skill_markdown"),
+    {% endif %}
     # App pages
     path("home", views.HomeView.as_view(), name="home"),
     path("settings", views.UserSettingsView.as_view(), name="settings"),

--- a/{{ cookiecutter.project_slug }}/apps/core/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/views.py
@@ -1,4 +1,4 @@
-from urllib.parse import urlencode
+from urllib.parse import urlsplit, urlunsplit, urlencode
 
 {% if cookiecutter.use_stripe == 'y' -%}
 import stripe
@@ -38,6 +38,67 @@ stripe.api_key = settings.STRIPE_SECRET_KEY
 
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
 
+{% if cookiecutter.use_mcp == 'y' -%}
+def build_absolute_public_url(path: str) -> str:
+    """Build a public URL from SITE_URL and upgrade non-local HTTP origins to HTTPS."""
+    base_url = settings.SITE_URL.rstrip("/")
+    parsed = urlsplit(base_url)
+    hostname = parsed.hostname or ""
+    is_local = hostname in {"localhost", "127.0.0.1", "0.0.0.0"} or hostname.endswith(".localhost")
+
+    if parsed.scheme == "http" and not is_local:
+        parsed = parsed._replace(scheme="https")
+        base_url = urlunsplit(parsed).rstrip("/")
+
+    return f"{base_url}/{path.lstrip('/')}"
+
+
+def skill_markdown(request):
+    """Return a copy/paste AgentSkill for this project's MCP server."""
+    mcp_url = build_absolute_public_url("/mcp/")
+    api_url = build_absolute_public_url("/api/user")
+    project_name = "{{ cookiecutter.project_name }}"
+    body = f"""---
+name: {{ cookiecutter.project_slug }}-mcp
+description: Use the hosted {project_name} MCP server and account API from coding agents.
+---
+
+# {project_name} MCP
+
+Use this skill when an agent needs to inspect the current authenticated {project_name} account/profile or connect to the project's MCP server.
+
+## Endpoints
+
+- MCP URL: `{mcp_url}`
+- User API: `{api_url}`
+
+## Authentication
+
+Use the user's API key from the app settings page. Do not commit or print the key.
+
+Supported MCP authentication methods:
+
+- `Authorization: Bearer <api_key>`
+- `X-API-Key: <api_key>`
+- `?api_key=<api_key>` on the MCP URL
+- `api_key` tool argument when a client cannot send headers
+
+The REST user endpoint supports the Bearer token, `X-API-Key`, and `?api_key=` methods.
+
+## Starter prompt for a coding agent
+
+```text
+Add {project_name} MCP support to this repo.
+
+Use MCP URL: {mcp_url}
+Use the user's {project_name} API key from environment variable {project_name.upper().replace(' ', '_')}_API_KEY.
+Do not hardcode, log, or commit the key.
+First verify the connection by calling the get_user_info MCP tool or GET {api_url} with the API key, then add the smallest useful integration for this codebase.
+Document how future agents should configure the MCP server locally.
+```
+"""
+    return HttpResponse(body, content_type="text/markdown; charset=utf-8")
+{% endif %}
 
 class HomeView(LoginRequiredMixin, TemplateView):
     login_url = "account_login"

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
@@ -1,0 +1,39 @@
+---
+title: MCP server
+---
+
+# MCP server
+
+{% if cookiecutter.use_mcp == 'y' -%}
+This project includes a hosted MCP server at `/mcp/` and a ready-to-copy agent skill at `/SKILL.md`.
+
+The first included MCP tool is `get_user_info`, which returns safe account/profile details for the authenticated API key. The same data is available through the REST endpoint `GET /api/user`.
+
+## Authentication
+
+Use the API key shown on the user settings page. Never hardcode it into source control.
+
+Supported MCP auth methods:
+
+- `Authorization: Bearer <api_key>`
+- `X-API-Key: <api_key>`
+- `?api_key=<api_key>` on the MCP URL
+- `api_key` tool argument for clients that cannot send headers
+
+## Give this prompt to a coding agent
+
+```text
+Add {{ cookiecutter.project_name }} MCP support to this repo.
+
+Use MCP URL: {{ cookiecutter.project_slug }} production URL + /mcp/
+Use the user's {{ cookiecutter.project_name }} API key from an environment variable. Do not hardcode, log, or commit the key.
+First verify the connection by calling the get_user_info MCP tool or GET /api/user with the API key, then add the smallest useful integration for this codebase.
+Document how future agents should configure the MCP server locally.
+```
+
+## Deployment note
+
+MCP uses ASGI. The generated server command runs `gunicorn {{ cookiecutter.project_slug }}.asgi:application` with `uvicorn_worker.UvicornWorker` when MCP is enabled.
+{% else -%}
+MCP was not enabled for this generated project. Regenerate with `use_mcp=y` to include the hosted MCP server, `/mcp/`, and `/SKILL.md`.
+{% endif %}

--- a/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
+++ b/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
@@ -34,6 +34,9 @@ navigation:
 
   features:
     - example-feature
+    {% if cookiecutter.use_mcp == 'y' -%}
+    - mcp
+    {% endif %}
 
   deployment:
     - render-deployment

--- a/{{ cookiecutter.project_slug }}/apps/mcp_server/apps.py
+++ b/{{ cookiecutter.project_slug }}/apps/mcp_server/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class McpServerConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "apps.mcp_server"

--- a/{{ cookiecutter.project_slug }}/apps/mcp_server/server.py
+++ b/{{ cookiecutter.project_slug }}/apps/mcp_server/server.py
@@ -1,0 +1,77 @@
+from typing import Annotated
+
+from django.db import close_old_connections
+from fastmcp import FastMCP
+from fastmcp.server.dependencies import get_http_request
+from pydantic import Field
+
+from apps.api.services import serialize_user_info
+from apps.core.models import Profile
+from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
+
+logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
+
+mcp = FastMCP(
+    name="{{ cookiecutter.project_name }}",
+    instructions=(
+        "{{ cookiecutter.project_description }} "
+        "Authenticate hosted MCP requests with an API key using one of: "
+        "Authorization: Bearer <api_key>, X-API-Key: <api_key>, "
+        "the api_key query parameter on the MCP URL, or the api_key tool argument."
+    ),
+)
+
+
+def _get_request_api_key() -> str:
+    try:
+        request = get_http_request()
+    except RuntimeError:
+        return ""
+
+    authorization = request.headers.get("authorization", "")
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() == "bearer" and token.strip():
+        return token.strip()
+
+    header_key = request.headers.get("x-api-key", "").strip()
+    if header_key:
+        return header_key
+
+    return request.query_params.get("api_key", "").strip()
+
+
+def _authenticate_profile(api_key: str | None = None) -> Profile:
+    key = (api_key or "").strip() or _get_request_api_key()
+    if not key:
+        raise PermissionError(
+            "Missing {{ cookiecutter.project_name }} API key. Provide Authorization: Bearer <api_key>, "
+            "X-API-Key, ?api_key=*** or the api_key tool argument."
+        )
+
+    try:
+        return Profile.objects.select_related("user").get(key=key)
+    except Profile.DoesNotExist as exc:
+        logger.warning("[MCP] Invalid API key")
+        raise PermissionError("Invalid {{ cookiecutter.project_name }} API key.") from exc
+
+
+@mcp.tool(
+    name="get_user_info",
+    description="Return safe account and profile details for the authenticated {{ cookiecutter.project_name }} user.",
+)
+def get_user_info(
+    api_key: Annotated[
+        str | None,
+        Field(
+            default=None,
+            description=(
+                "Optional {{ cookiecutter.project_name }} API key. Hosted clients may instead send it as "
+                "Authorization: Bearer <api_key>, X-API-Key, or ?api_key= on the MCP URL."
+            ),
+        ),
+    ] = None,
+) -> dict:
+    """Return safe user/profile details for the authenticated API key."""
+    close_old_connections()
+    profile = _authenticate_profile(api_key)
+    return serialize_user_info(profile)

--- a/{{ cookiecutter.project_slug }}/apps/mcp_server/tests/test_server.py
+++ b/{{ cookiecutter.project_slug }}/apps/mcp_server/tests/test_server.py
@@ -1,0 +1,61 @@
+from types import SimpleNamespace
+
+import anyio
+import pytest
+from fastmcp import Client
+
+from apps.mcp_server.server import mcp
+
+
+def _profile():
+    user = SimpleNamespace(
+        id=7,
+        email="ada@example.com",
+        username="ada",
+        first_name="Ada",
+        last_name="Lovelace",
+        date_joined="2026-05-14T00:00:00Z",
+        is_staff=False,
+        is_superuser=False,
+        get_full_name=lambda: "Ada Lovelace",
+    )
+    return SimpleNamespace(
+        id=11,
+        user=user,
+        state="signed_up",
+        {% if cookiecutter.use_stripe == 'y' -%}
+        has_active_subscription=False,
+        {% endif %}
+    )
+
+
+def test_get_user_info_mcp_tool_returns_safe_user_data(monkeypatch):
+    async def run():
+        monkeypatch.setattr(
+            "apps.mcp_server.server._authenticate_profile",
+            lambda api_key=None: _profile(),
+        )
+
+        async with Client(mcp) as client:
+            result = await client.call_tool("get_user_info", {"api_key": "secret-key"})
+
+        payload = result.data
+        assert payload["email"] == "ada@example.com"
+        assert payload["profile"]["id"] == 11
+        assert "key" not in payload
+
+    anyio.run(run)
+
+
+def test_get_user_info_mcp_tool_rejects_invalid_api_key(monkeypatch):
+    def reject(api_key=None):
+        raise PermissionError("Invalid {{ cookiecutter.project_name }} API key")
+
+    async def run():
+        monkeypatch.setattr("apps.mcp_server.server._authenticate_profile", reject)
+
+        async with Client(mcp) as client:
+            with pytest.raises(Exception, match="Invalid {{ cookiecutter.project_name }} API key"):
+                await client.call_tool("get_user_info", {"api_key": "not-real"})
+
+    anyio.run(run)

--- a/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
@@ -56,7 +56,11 @@ if [ "$server" = true ]; then
     echo "Starting {{ cookiecutter.project_name }} server..."
     python manage.py collectstatic --noinput
     python manage.py migrate --noinput
+    {% if cookiecutter.use_mcp == 'y' -%}
+    exec gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker
+    {% else -%}
     exec gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
+    {% endif %}
 else
     echo "Starting {{ cookiecutter.project_name }} workers..."
     exec python manage.py qcluster

--- a/{{ cookiecutter.project_slug }}/pyproject.toml
+++ b/{{ cookiecutter.project_slug }}/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "django-widget-tweaks>=1.5.1",
     "fido2>=2.2.0,<3",
     "gunicorn>=26.0.0",
+    {% if cookiecutter.use_mcp == 'y' -%}
+    "fastmcp>=2.14.0",
+    "starlette>=0.50.0",
+    "uvicorn-worker>=0.4.0",
+    {% endif %}
     "ipython>=9.13.0",
     "markdown>=3.10.2",
     "pillow>=12.2.0",

--- a/{{ cookiecutter.project_slug }}/render.yaml
+++ b/{{ cookiecutter.project_slug }}/render.yaml
@@ -7,7 +7,7 @@ services:
       npm ci &&
       npm run build &&
       python manage.py collectstatic --noinput
-    startCommand: python manage.py migrate && gunicorn {{ cookiecutter.project_slug }}.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --threads 2 --timeout 120
+    startCommand: python manage.py migrate && {% if cookiecutter.use_mcp == 'y' -%}gunicorn {{ cookiecutter.project_slug }}.asgi:application --bind 0.0.0.0:$PORT --workers 2 --worker-class uvicorn_worker.UvicornWorker --timeout 120{% else -%}gunicorn {{ cookiecutter.project_slug }}.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --threads 2 --timeout 120{% endif %}
     plan: free
     healthCheckPath: /
 

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/asgi.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/asgi.py
@@ -2,15 +2,40 @@
 ASGI config for {{ cookiecutter.project_slug }} project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/4.0/howto/deployment/asgi/
 """
 
 import os
 
 from django.core.asgi import get_asgi_application
+{% if cookiecutter.use_mcp == 'y' -%}
+from starlette.applications import Starlette
+from starlette.requests import Request
+from starlette.responses import RedirectResponse
+from starlette.routing import Mount, Route
+{% endif %}
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ cookiecutter.project_slug }}.settings")
 
+{% if cookiecutter.use_mcp == 'y' -%}
+django_application = get_asgi_application()
+
+from apps.mcp_server.server import mcp  # noqa: E402
+
+mcp_application = mcp.http_app(path="/")
+
+
+def redirect_mcp(request: Request) -> RedirectResponse:
+    return RedirectResponse(str(request.url.replace(path="/mcp/")), status_code=307)
+
+
+application = Starlette(
+    routes=[
+        Route("/mcp", endpoint=redirect_mcp, methods=["GET", "POST", "DELETE"]),
+        Mount("/mcp", app=mcp_application),
+        Mount("/", app=django_application),
+    ],
+    lifespan=mcp_application.lifespan,
+)
+{% else -%}
 application = get_asgi_application()
+{% endif %}

--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.project_slug }}/settings.py
@@ -121,6 +121,9 @@ THIRD_PARTY_APPS = [
 CUSTOM_APPS = [
     "apps.core.CoreConfig",
     "apps.api.ApiConfig",
+    {% if cookiecutter.use_mcp == 'y' -%}
+    "apps.mcp_server.apps.McpServerConfig",
+    {% endif %}
     "apps.pages.PagesConfig",
     {% if cookiecutter.generate_blog == 'y' -%}
     "apps.blog.BlogConfig",


### PR DESCRIPTION
## Summary
- add always-on GET /api/user endpoint backed by a shared safe user/profile serializer
- add optional use_mcp cookiecutter flag, defaulting to n, that includes hosted /mcp/ server and /SKILL.md agent skill
- add MCP docs, README setup prompt, ASGI deployment commands, dependencies, and generation tests

## Tests
- uv run pytest tests/test_cookiecutter_template.py -q
- generated MCP smoke project: uv run pytest apps/api/tests.py apps/mcp_server/tests/test_server.py -q
- generated MCP smoke project: uv run python manage.py check