### PR TITLE
feat: upstream FileBridge UI and docs patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Fix pricing page dark mode styles.
 - Make `use_stripe = n` generation remove subscription-only states, API fields, pricing leftovers, and Stripe-specific legal copy.
 ### Added
+- Generated projects now include FileBridge-proven app UI primitives, authenticated app-shell docs, an API Reference section with current-user API context, copyable/high-contrast docs code blocks, and an optional MCP dashboard agent setup prompt.
 - Generated projects now include a generic, Google DESIGN.md-style `DESIGN.md` design-system source of truth plus README/docs guidance for human and AI-agent contributors.
 - CI now includes a real Cookiecutter CLI smoke test that renders a project end-to-end and fails on non-zero generation exits.
 - Optional `use_chatwoot` generator flag for Chatwoot support chat, including self-hosted/cloud setup docs, HMAC identity validation support, and runtime-off defaults.

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -174,6 +174,7 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     _assert_contains(project_dir / "frontend" / "templates" / "docs" / "base_docs.html", "data-controller=\"toc docs-code\"")
     _assert_contains(project_dir / "frontend" / "templates" / "docs" / "docs_page.html", "noindex, nofollow")
     _assert_contains(project_dir / "frontend" / "src" / "controllers" / "docs_code_controller.js", "Copy failed")
+    _assert_contains(project_dir / "frontend" / "src" / "utils" / "clipboard.js", "document.execCommand")
     _assert_contains(project_dir / "frontend" / "src" / "styles" / "index.css", ".docs-code-blocks pre code *")
     _assert_contains(project_dir / "frontend" / "src" / "styles" / "index.css", "font-weight: 500 !important")
     assert not (

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -167,6 +167,15 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     assert (project_dir / "apps" / "docs").exists()
     assert (project_dir / "apps" / "docs" / "content" / "getting-started" / "design-system.md").exists()
     _assert_contains(project_dir / "apps" / "docs" / "navigation.yaml", "- design-system")
+    _assert_contains(project_dir / "apps" / "docs" / "navigation.yaml", "api-reference")
+    _assert_contains(project_dir / "apps" / "docs" / "views.py", "@login_required")
+    _assert_contains(project_dir / "apps" / "docs" / "views.py", "Template(post.content).render")
+    _assert_contains(project_dir / "apps" / "docs" / "content" / "api-reference" / "introduction.md", "{{ api_key_full }}")
+    _assert_contains(project_dir / "frontend" / "templates" / "docs" / "base_docs.html", "data-controller=\"toc docs-code\"")
+    _assert_contains(project_dir / "frontend" / "templates" / "docs" / "docs_page.html", "noindex, nofollow")
+    _assert_contains(project_dir / "frontend" / "src" / "controllers" / "docs_code_controller.js", "Copy failed")
+    _assert_contains(project_dir / "frontend" / "src" / "styles" / "index.css", ".docs-code-blocks pre code *")
+    _assert_contains(project_dir / "frontend" / "src" / "styles" / "index.css", "font-weight: 500 !important")
     assert not (
         Path(__file__).resolve().parents[1]
         / "{{ cookiecutter.project_slug }}"
@@ -334,8 +343,13 @@ def test_use_mcp_includes_hosted_server_skill_and_docs(tmp_path: Path) -> None:
     _assert_contains(project_dir / "render.yaml", "uvicorn_worker.UvicornWorker")
     _assert_contains(project_dir / "apps" / "core" / "urls.py", "SKILL.md")
     _assert_contains(project_dir / "apps" / "core" / "views.py", "def skill_markdown")
+    _assert_contains(project_dir / "apps" / "core" / "views.py", "def build_agent_setup_prompt")
+    _assert_contains(project_dir / "frontend" / "templates" / "pages" / "home.html", "Copy/paste prompt")
+    _assert_contains(project_dir / "frontend" / "src" / "controllers" / "copy_controller.js", "Copy failed")
     _assert_contains(project_dir / "apps" / "docs" / "content" / "features" / "mcp.md", "get_user_info")
+    _assert_contains(project_dir / "apps" / "docs" / "content" / "features" / "mcp.md", "{{ agent_setup_prompt }}")
     _assert_contains(project_dir / "README.md", "Hosted MCP server")
+
 
 def test_generate_without_blog_removes_blog_app_and_templates(tmp_path: Path) -> None:
     project_dir = _generate(tmp_path, generate_blog="n")

--- a/{{ cookiecutter.project_slug }}/apps/core/tests/test_views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/tests/test_views.py
@@ -1,5 +1,8 @@
 import pytest
+from django.test import override_settings
 from django.urls import reverse
+
+from apps.core.views import build_absolute_public_url
 
 
 @pytest.mark.django_db
@@ -13,3 +16,32 @@ class TestHomeView:
         url = reverse("home")
         response = auth_client.get(url)
         assert "pages/home.html" in [t.name for t in response.templates]
+
+    {% if cookiecutter.use_mcp == 'y' -%}
+    def test_home_view_includes_copyable_agent_prompt(self, auth_client, profile):
+        url = reverse("home")
+        response = auth_client.get(url)
+        content = response.content.decode()
+
+        assert response.status_code == 200
+        assert "Copy/paste prompt" in content
+        assert "data-controller=\"copy\"" in content
+        assert "/mcp/" in content
+        assert "/SKILL.md" in content
+        assert profile.key in content
+    {% endif %}
+
+
+@override_settings(SITE_URL="http://example.com")
+def test_build_absolute_public_url_upgrades_non_local_http():
+    assert build_absolute_public_url("/api/user") == "https://example.com/api/user"
+
+
+@override_settings(SITE_URL="http://notlocalhost.example")
+def test_build_absolute_public_url_does_not_treat_hostname_substrings_as_local():
+    assert build_absolute_public_url("/api/user") == "https://notlocalhost.example/api/user"
+
+
+@override_settings(SITE_URL="http://localhost:8000")
+def test_build_absolute_public_url_preserves_localhost_http():
+    assert build_absolute_public_url("/api/user") == "http://localhost:8000/api/user"

--- a/{{ cookiecutter.project_slug }}/apps/core/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/views.py
@@ -56,7 +56,8 @@ def build_absolute_public_url(path: str) -> str:
 {% if cookiecutter.use_mcp == 'y' -%}
 def build_agent_setup_prompt(request):
     """Build the dashboard copy/paste prompt for connecting a coding agent."""
-    api_key = request.user.profile.key
+    profile, _created = Profile.objects.get_or_create(user=request.user)
+    api_key = profile.key
     project_name = "{{ cookiecutter.project_name }}"
     env_var = "{{ cookiecutter.project_slug.upper() }}_API_KEY"
     mcp_url = build_absolute_public_url("/mcp/")

--- a/{{ cookiecutter.project_slug }}/apps/core/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/core/views.py
@@ -38,13 +38,13 @@ stripe.api_key = settings.STRIPE_SECRET_KEY
 
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
 
-{% if cookiecutter.use_mcp == 'y' -%}
+
 def build_absolute_public_url(path: str) -> str:
     """Build a public URL from SITE_URL and upgrade non-local HTTP origins to HTTPS."""
     base_url = settings.SITE_URL.rstrip("/")
     parsed = urlsplit(base_url)
     hostname = parsed.hostname or ""
-    is_local = hostname in {"localhost", "127.0.0.1", "0.0.0.0"} or hostname.endswith(".localhost")
+    is_local = hostname in {"localhost", "127.0.0.1", "0.0.0.0", "::1"} or hostname.endswith(".localhost")
 
     if parsed.scheme == "http" and not is_local:
         parsed = parsed._replace(scheme="https")
@@ -53,11 +53,34 @@ def build_absolute_public_url(path: str) -> str:
     return f"{base_url}/{path.lstrip('/')}"
 
 
+{% if cookiecutter.use_mcp == 'y' -%}
+def build_agent_setup_prompt(request):
+    """Build the dashboard copy/paste prompt for connecting a coding agent."""
+    api_key = request.user.profile.key
+    project_name = "{{ cookiecutter.project_name }}"
+    env_var = "{{ cookiecutter.project_slug.upper() }}_API_KEY"
+    mcp_url = build_absolute_public_url("/mcp/")
+    api_url = build_absolute_public_url("/api/user")
+    skill_url = build_absolute_public_url("/SKILL.md")
+    return f"""Add {project_name} MCP support to this repo.
+
+Use MCP URL: {mcp_url}
+Use REST User API URL: {api_url}
+Use Agent Skill URL: {skill_url}
+Use this API key only as a local secret: {api_key}
+
+Store the key in environment variable {env_var}. Do not hardcode, log, print, or commit it.
+First verify the connection by calling the get_user_info MCP tool or GET {api_url} with the API key.
+Then add the smallest useful integration for this codebase and document how future agents should configure the MCP server locally.
+"""
+
+
 def skill_markdown(request):
     """Return a copy/paste AgentSkill for this project's MCP server."""
     mcp_url = build_absolute_public_url("/mcp/")
     api_url = build_absolute_public_url("/api/user")
     project_name = "{{ cookiecutter.project_name }}"
+    env_var = "{{ cookiecutter.project_slug.upper() }}_API_KEY"
     body = f"""---
 name: {{ cookiecutter.project_slug }}-mcp
 description: Use the hosted {project_name} MCP server and account API from coding agents.
@@ -91,7 +114,7 @@ The REST user endpoint supports the Bearer token, `X-API-Key`, and `?api_key=` m
 Add {project_name} MCP support to this repo.
 
 Use MCP URL: {mcp_url}
-Use the user's {project_name} API key from environment variable {project_name.upper().replace(' ', '_')}_API_KEY.
+Use the user's {project_name} API key from environment variable {env_var}.
 Do not hardcode, log, or commit the key.
 First verify the connection by calling the get_user_info MCP tool or GET {api_url} with the API key, then add the smallest useful integration for this codebase.
 Document how future agents should configure the MCP server locally.
@@ -114,6 +137,11 @@ class HomeView(LoginRequiredMixin, TemplateView):
             context["show_confetti"] = True
         elif payment_status == "failed":
             messages.error(self.request, "Something went wrong with the payment.")
+        {% endif %}
+
+        {% if cookiecutter.use_mcp == 'y' -%}
+        context["agent_setup_prompt"] = build_agent_setup_prompt(self.request)
+        context["agent_instructions_url"] = build_absolute_public_url("/SKILL.md")
         {% endif %}
 
         return context

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/introduction.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/introduction.md
@@ -4,6 +4,8 @@ description: Learn how {{ cookiecutter.project_name }} API authentication works 
 keywords: {{ cookiecutter.project_name }} API, API authentication, OpenAPI docs
 ---
 
+# Introduction
+
 {{ cookiecutter.project_name }} exposes authenticated REST endpoints for account checks and product-specific integrations.
 
 ## Base URL

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/introduction.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/introduction.md
@@ -1,0 +1,42 @@
+---
+title: Introduction
+description: Learn how {{ cookiecutter.project_name }} API authentication works and where to find generated API docs.
+keywords: {{ cookiecutter.project_name }} API, API authentication, OpenAPI docs
+---
+
+{{ cookiecutter.project_name }} exposes authenticated REST endpoints for account checks and product-specific integrations.
+
+## Base URL
+
+```text
+{% raw %}{{ api_base_url }}{% endraw %}
+```
+
+## Authentication
+
+Use your API key as a bearer token:
+
+```http
+Authorization: Bearer {% raw %}{{ api_key_full }}{% endraw %}
+```
+
+Example request:
+
+```bash
+curl -H "Authorization: Bearer {% raw %}{{ api_key_full }}{% endraw %}" "{% raw %}{{ api_base_url }}{% endraw %}/user"
+```
+
+Authenticated docs show your full key so you can copy it into trusted tools. Treat it like a password: do not put it in frontend code, public repos, shared screenshots, or logs.
+
+## Interactive API docs
+
+{{ cookiecutter.project_name }} also exposes generated API docs from the backend schema:
+
+[Open generated API docs]({% raw %}{{ api_docs_url }}{% endraw %})
+
+Use those generated docs when you want request/response schemas or to inspect lower-level endpoint details. Use this docs section for workflow-oriented guidance.
+
+## Sections
+
+- **User API** — verify a key and inspect safe profile details.
+- Add product-specific API pages here as you add user-facing endpoints.

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/user.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/user.md
@@ -4,6 +4,8 @@ description: Use the {{ cookiecutter.project_name }} user endpoint to verify API
 keywords: {{ cookiecutter.project_name }} API, user API, profile API
 ---
 
+# User API
+
 Use the user endpoint to verify an API key and fetch safe account/profile details for the authenticated user.
 
 ## Authentication

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/user.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/api-reference/user.md
@@ -1,0 +1,50 @@
+---
+title: User API
+description: Use the {{ cookiecutter.project_name }} user endpoint to verify API access and inspect safe profile details.
+keywords: {{ cookiecutter.project_name }} API, user API, profile API
+---
+
+Use the user endpoint to verify an API key and fetch safe account/profile details for the authenticated user.
+
+## Authentication
+
+```http
+Authorization: Bearer {% raw %}{{ api_key_full }}{% endraw %}
+```
+
+Your API base URL is:
+
+```text
+{% raw %}{{ api_base_url }}{% endraw %}
+```
+
+## Get current user
+
+```http
+GET {% raw %}{{ api_base_url }}{% endraw %}/user
+```
+
+Example:
+
+```bash
+curl -H "Authorization: Bearer {% raw %}{{ api_key_full }}{% endraw %}" "{% raw %}{{ api_base_url }}{% endraw %}/user"
+```
+
+Example response:
+
+```json
+{
+  "email": "{% raw %}{{ user_email }}{% endraw %}",
+  "profile": {
+    "state": "signed_up"
+  }
+}
+```
+
+The response does **not** include your API key or privileged admin flags.
+
+## When to use this endpoint
+
+- Check that an integration is authenticated correctly.
+- Give an AI agent a low-risk connectivity test before it does product-specific work.
+- Confirm which {{ cookiecutter.project_name }} account a key belongs to.

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
@@ -1,13 +1,19 @@
 ---
-title: MCP server
+title: MCP access
 ---
 
-# MCP server
-
 {% if cookiecutter.use_mcp == 'y' -%}
-This project includes a hosted MCP server at `/mcp/` and a ready-to-copy agent skill at `/SKILL.md`.
+This project includes a hosted MCP server at `/mcp/`, a ready-to-copy agent skill at `/SKILL.md`, and a dashboard prompt that includes the exact URLs and API key for the current user.
 
 The first included MCP tool is `get_user_info`, which returns safe account/profile details for the authenticated API key. The same data is available through the REST endpoint `GET /api/user`.
+
+## URLs
+
+```text
+MCP URL: {% raw %}{{ mcp_url }}{% endraw %}
+Skill URL: {% raw %}{{ skill_url }}{% endraw %}
+User API: {% raw %}{{ api_base_url }}{% endraw %}/user
+```
 
 ## Authentication
 
@@ -23,17 +29,12 @@ Supported MCP auth methods:
 ## Give this prompt to a coding agent
 
 ```text
-Add {{ cookiecutter.project_name }} MCP support to this repo.
-
-Use MCP URL: {{ cookiecutter.project_slug }} production URL + /mcp/
-Use the user's {{ cookiecutter.project_name }} API key from an environment variable. Do not hardcode, log, or commit the key.
-First verify the connection by calling the get_user_info MCP tool or GET /api/user with the API key, then add the smallest useful integration for this codebase.
-Document how future agents should configure the MCP server locally.
+{% raw %}{{ agent_setup_prompt }}{% endraw %}
 ```
 
 ## Deployment note
 
 MCP uses ASGI. The generated server command runs `gunicorn {{ cookiecutter.project_slug }}.asgi:application` with `uvicorn_worker.UvicornWorker` when MCP is enabled.
 {% else -%}
-MCP was not enabled for this generated project. Regenerate with `use_mcp=y` to include the hosted MCP server, `/mcp/`, and `/SKILL.md`.
+MCP was not enabled for this generated project. Regenerate with `use_mcp=y` to include the hosted MCP server, `/mcp/`, `/SKILL.md`, and the dashboard copy/paste agent prompt.
 {% endif %}

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/features/mcp.md
@@ -2,6 +2,8 @@
 title: MCP access
 ---
 
+# MCP access
+
 {% if cookiecutter.use_mcp == 'y' -%}
 This project includes a hosted MCP server at `/mcp/`, a ready-to-copy agent skill at `/SKILL.md`, and a dashboard prompt that includes the exact URLs and API key for the current user.
 

--- a/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
+++ b/{{ cookiecutter.project_slug }}/apps/docs/navigation.yaml
@@ -3,34 +3,15 @@
 # Define the order of categories and pages in the sidebar navigation.
 # If a category or page is not listed here, it will be added alphabetically
 # at the end of the respective section.
-#
-# Configuration format:
-# - Use category directory names as keys (e.g., 'getting-started', not 'Getting Started')
-# - List page file names without .md extension (e.g., 'introduction', not 'introduction.md')
-# - Order matters: categories and pages appear in the order listed
-#
-# How it works:
-# 1. Categories listed here appear first, in the order specified
-# 2. Categories not listed appear after, in alphabetical order
-# 3. Within each category, pages listed appear first, in the order specified
-# 4. Pages not listed appear after, in alphabetical order
-#
-# Example:
-#   navigation:
-#     getting-started:
-#       - introduction
-#       - quickstart
-#     api:
-#       - overview
-#       - authentication
-#
-# Result: Getting Started section first, API section second, any other sections alphabetically after
 
 navigation:
   getting-started:
     - introduction
     - design-system
-    # Any pages not listed here will appear after these, in alphabetical order
+
+  api-reference:
+    - introduction
+    - user
 
   features:
     - example-feature
@@ -45,5 +26,3 @@ navigation:
     {% if cookiecutter.use_chatwoot == 'y' -%}
     - chatwoot
     {% endif %}
-
-  # Any categories not listed here will appear after these, in alphabetical order

--- a/{{ cookiecutter.project_slug }}/apps/docs/tests.py
+++ b/{{ cookiecutter.project_slug }}/apps/docs/tests.py
@@ -1,1 +1,33 @@
-# Create your tests here.
+import pytest
+from django.urls import reverse
+
+from apps.docs.views import get_docs_navigation
+
+
+@pytest.mark.django_db
+def test_docs_require_login(client):
+    response = client.get(reverse("docs_home"))
+    assert response.status_code == 302
+    assert "/accounts/login/" in response["Location"]
+
+
+@pytest.mark.django_db
+def test_docs_render_in_authenticated_app_shell(auth_client, profile):
+    response = auth_client.get(reverse("docs_page", kwargs={"category": "api-reference", "page": "introduction"}))
+
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "API Reference" in content
+    assert "noindex, nofollow" in content
+    assert "docs-code-blocks" in content
+    assert "data-controller=\"toc docs-code\"" in content
+    assert profile.key in content
+    assert "Work in Progress" not in content
+
+
+def test_docs_navigation_uses_frontmatter_titles():
+    navigation = get_docs_navigation()
+    api_reference = next(section for section in navigation if section["category_slug"] == "api-reference")
+
+    assert api_reference["category"] == "API Reference"
+    assert [page["title"] for page in api_reference["pages"]][:2] == ["Introduction", "User API"]

--- a/{{ cookiecutter.project_slug }}/apps/docs/urls.py
+++ b/{{ cookiecutter.project_slug }}/apps/docs/urls.py
@@ -1,13 +1,8 @@
 from django.urls import path
-from django.views.generic import RedirectView
 
-
-from apps.docs.views import docs_page_view
+from apps.docs.views import docs_home_view, docs_page_view
 
 urlpatterns = [
-    path("", RedirectView.as_view(
-        url="/docs/getting-started/introduction/",
-        permanent=False,
-    ), name="docs_home"),
+    path("", docs_home_view, name="docs_home"),
     path("<str:category>/<str:page>/", docs_page_view, name="docs_page"),
 ]

--- a/{{ cookiecutter.project_slug }}/apps/docs/views.py
+++ b/{{ cookiecutter.project_slug }}/apps/docs/views.py
@@ -4,9 +4,17 @@ import frontmatter
 import markdown
 import yaml
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.http import Http404
-from django.shortcuts import render
+from django.shortcuts import redirect, render
+from django.template import Context, Template
+from django.urls import reverse
 
+from apps.core.models import Profile
+from apps.core.views import build_absolute_public_url
+{% if cookiecutter.use_mcp == 'y' -%}
+from apps.core.views import build_agent_setup_prompt
+{% endif -%}
 from {{ cookiecutter.project_slug }}.utils import get_{{ cookiecutter.project_slug }}_logger
 
 logger = get_{{ cookiecutter.project_slug }}_logger(__name__)
@@ -28,6 +36,21 @@ def load_navigation_config():
             return config.get("navigation", {}) if config else {}
     except Exception:
         return {}
+
+
+def get_page_title(markdown_file, fallback):
+    try:
+        with open(markdown_file, encoding="utf-8") as file:
+            post = frontmatter.load(file)
+        return post.get("title", fallback)
+    except Exception:
+        return fallback
+
+
+def get_category_title(category_slug):
+    if category_slug == "api-reference":
+        return "API Reference"
+    return category_slug.replace("-", " ").title()
 
 
 def get_docs_navigation():  # noqa: C901
@@ -60,7 +83,7 @@ def get_docs_navigation():  # noqa: C901
 
     for category_slug in ordered_categories:
         category_dir = all_categories[category_slug]
-        category_name = category_slug.replace("-", " ").title()
+        category_name = get_category_title(category_slug)
 
         all_pages = {}
         for markdown_file in category_dir.glob("*.md"):
@@ -83,7 +106,7 @@ def get_docs_navigation():  # noqa: C901
             pages.append(
                 {
                     "slug": page_slug,
-                    "title": page_title,
+                    "title": get_page_title(all_pages[page_slug], page_title),
                     "url": f"/docs/{category_slug}/{page_slug}/",
                 }
             )
@@ -144,9 +167,15 @@ def get_previous_and_next_pages(navigation, current_category, current_page):
     return previous_page, next_page
 
 
+@login_required
+def docs_home_view(request):
+    return redirect(reverse("docs_page", kwargs={"category": "getting-started", "page": "introduction"}))
+
+
+@login_required
 def docs_page_view(request, category, page):
     """
-    Render a documentation page from markdown file with frontmatter support.
+    Render an authenticated documentation page from markdown with frontmatter and user context.
     """
     content_dir = Path(settings.BASE_DIR) / "apps" / "docs" / "content"
     markdown_file = content_dir / category / f"{page}.md"
@@ -158,15 +187,30 @@ def docs_page_view(request, category, page):
         with open(markdown_file, encoding="utf-8") as file:
             post = frontmatter.load(file)
 
-        markdown_html = markdown.markdown(
-            post.content, extensions=["fenced_code", "tables", "codehilite"]
-        )
+        profile, _created = Profile.objects.get_or_create(user=request.user)
+        api_key = profile.key
+        docs_template_context = {
+            "api_base_url": build_absolute_public_url("/api/").rstrip("/"),
+            "api_key": api_key,
+            "api_key_masked": f"{api_key[:8]}••••••••",
+            "api_key_full": api_key,
+            "api_docs_url": build_absolute_public_url("/api/docs"),
+            {% if cookiecutter.use_mcp == 'y' -%}
+            "agent_setup_prompt": build_agent_setup_prompt(request),
+            "mcp_url": build_absolute_public_url("/mcp/"),
+            "skill_url": build_absolute_public_url("/SKILL.md"),
+            {% endif -%}
+            "site_url": build_absolute_public_url("/").rstrip("/"),
+            "user_email": request.user.email,
+        }
+        rendered_markdown = Template(post.content).render(Context(docs_template_context))
+        markdown_html = markdown.markdown(rendered_markdown, extensions=["fenced_code", "tables"])
 
         navigation = get_docs_navigation()
         previous_page, next_page = get_previous_and_next_pages(navigation, category, page)
 
         default_page_title = page.replace("-", " ").title()
-        default_category_title = category.replace("-", " ").title()
+        default_category_title = get_category_title(category)
 
         context = {
             "content": markdown_html,

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/copy_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/copy_controller.js
@@ -1,0 +1,46 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["source", "label"];
+
+  async copy() {
+    const text = this.sourceTarget.value || this.sourceTarget.textContent || "";
+    const copied = await this.copyText(text);
+    const original = this.hasLabelTarget ? this.labelTarget.textContent : null;
+
+    if (this.hasLabelTarget) {
+      this.labelTarget.textContent = copied ? "Copied" : "Copy failed";
+      window.clearTimeout(Number(this.labelTarget.dataset.resetTimer));
+      this.labelTarget.dataset.resetTimer = window.setTimeout(() => {
+        this.labelTarget.textContent = original;
+      }, 1600);
+    }
+  }
+
+  async copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (error) {
+        // Fall back for restricted clipboard contexts.
+      }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      return document.execCommand("copy");
+    } catch (error) {
+      return false;
+    } finally {
+      textarea.remove();
+    }
+  }
+}

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/copy_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/copy_controller.js
@@ -1,11 +1,13 @@
 import { Controller } from "@hotwired/stimulus";
 
+import { copyText } from "../utils/clipboard";
+
 export default class extends Controller {
   static targets = ["source", "label"];
 
   async copy() {
     const text = this.sourceTarget.value || this.sourceTarget.textContent || "";
-    const copied = await this.copyText(text);
+    const copied = await copyText(text);
     const original = this.hasLabelTarget ? this.labelTarget.textContent : null;
 
     if (this.hasLabelTarget) {
@@ -14,33 +16,6 @@ export default class extends Controller {
       this.labelTarget.dataset.resetTimer = window.setTimeout(() => {
         this.labelTarget.textContent = original;
       }, 1600);
-    }
-  }
-
-  async copyText(text) {
-    if (navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch (error) {
-        // Fall back for restricted clipboard contexts.
-      }
-    }
-
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.top = "-9999px";
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    try {
-      return document.execCommand("copy");
-    } catch (error) {
-      return false;
-    } finally {
-      textarea.remove();
     }
   }
 }

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/docs_code_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/docs_code_controller.js
@@ -1,0 +1,73 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() {
+    this.addCopyButtons();
+  }
+
+  addCopyButtons() {
+    const blocks = this.element.querySelectorAll("pre");
+
+    blocks.forEach((block) => {
+      if (block.dataset.copyEnhanced === "true") {
+        return;
+      }
+
+      const code = block.querySelector("code");
+      if (!code) {
+        return;
+      }
+
+      block.dataset.copyEnhanced = "true";
+      const wrapper = document.createElement("div");
+      wrapper.className = "group relative my-6";
+      block.parentNode.insertBefore(wrapper, block);
+      wrapper.appendChild(block);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "absolute right-3 top-3 rounded-lg border border-gray-700 bg-gray-900/90 px-2.5 py-1 text-xs font-semibold text-gray-200 opacity-0 shadow-sm transition hover:bg-gray-800 focus:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-{{ cookiecutter.project_main_color }}-500 group-hover:opacity-100";
+      button.textContent = "Copy";
+      button.addEventListener("click", () => this.copyCode(code.textContent, button));
+      wrapper.appendChild(button);
+    });
+  }
+
+  async copyCode(text, button) {
+    const copied = await this.copyText(text);
+    const original = button.dataset.originalLabel || button.textContent;
+    button.dataset.originalLabel = original;
+    button.textContent = copied ? "Copied" : "Copy failed";
+    window.clearTimeout(Number(button.dataset.resetTimer));
+    button.dataset.resetTimer = window.setTimeout(() => {
+      button.textContent = original;
+    }, 1600);
+  }
+
+  async copyText(text) {
+    if (navigator.clipboard?.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return true;
+      } catch (error) {
+        // Fall back for restricted clipboard contexts.
+      }
+    }
+
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    try {
+      return document.execCommand("copy");
+    } catch (error) {
+      return false;
+    } finally {
+      textarea.remove();
+    }
+  }
+}

--- a/{{ cookiecutter.project_slug }}/frontend/src/controllers/docs_code_controller.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/controllers/docs_code_controller.js
@@ -1,5 +1,7 @@
 import { Controller } from "@hotwired/stimulus";
 
+import { copyText } from "../utils/clipboard";
+
 export default class extends Controller {
   connect() {
     this.addCopyButtons();
@@ -34,7 +36,7 @@ export default class extends Controller {
   }
 
   async copyCode(text, button) {
-    const copied = await this.copyText(text);
+    const copied = await copyText(text);
     const original = button.dataset.originalLabel || button.textContent;
     button.dataset.originalLabel = original;
     button.textContent = copied ? "Copied" : "Copy failed";
@@ -42,32 +44,5 @@ export default class extends Controller {
     button.dataset.resetTimer = window.setTimeout(() => {
       button.textContent = original;
     }, 1600);
-  }
-
-  async copyText(text) {
-    if (navigator.clipboard?.writeText) {
-      try {
-        await navigator.clipboard.writeText(text);
-        return true;
-      } catch (error) {
-        // Fall back for restricted clipboard contexts.
-      }
-    }
-
-    const textarea = document.createElement("textarea");
-    textarea.value = text;
-    textarea.setAttribute("readonly", "");
-    textarea.style.position = "fixed";
-    textarea.style.top = "-9999px";
-    document.body.appendChild(textarea);
-    textarea.select();
-
-    try {
-      return document.execCommand("copy");
-    } catch (error) {
-      return false;
-    } finally {
-      textarea.remove();
-    }
   }
 }

--- a/{{ cookiecutter.project_slug }}/frontend/src/styles/index.css
+++ b/{{ cookiecutter.project_slug }}/frontend/src/styles/index.css
@@ -3,3 +3,72 @@
 @config "../../../tailwind.config.js";
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
+
+@layer components {
+  .app-focus {
+    @apply focus:outline-none focus-visible:ring-2 focus-visible:ring-{{ cookiecutter.project_main_color }}-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-950;
+  }
+
+  .app-card {
+    @apply rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900;
+  }
+
+  .app-panel {
+    @apply rounded-2xl border border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-950/70;
+  }
+
+  .app-button-primary {
+    @apply inline-flex min-h-11 items-center justify-center rounded-xl bg-{{ cookiecutter.project_main_color }}-600 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-{{ cookiecutter.project_main_color }}-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-{{ cookiecutter.project_main_color }}-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:bg-{{ cookiecutter.project_main_color }}-500 dark:text-gray-950 dark:hover:bg-{{ cookiecutter.project_main_color }}-400 dark:focus-visible:ring-offset-gray-950;
+  }
+
+  .app-button-secondary {
+    @apply inline-flex min-h-11 items-center justify-center rounded-xl border border-gray-300 bg-white px-5 py-2.5 text-sm font-semibold text-gray-900 shadow-sm transition hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-{{ cookiecutter.project_main_color }}-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100 dark:hover:bg-gray-800 dark:focus-visible:ring-offset-gray-950;
+  }
+
+  .app-button-danger {
+    @apply inline-flex min-h-11 items-center justify-center rounded-xl bg-red-600 px-5 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-60 dark:focus-visible:ring-offset-gray-950;
+  }
+
+  .app-input {
+    @apply rounded-xl border-gray-300 bg-white text-gray-900 shadow-sm placeholder:text-gray-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-{{ cookiecutter.project_main_color }}-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:border-gray-700 dark:bg-gray-950 dark:text-gray-100 dark:placeholder:text-gray-500 dark:focus-visible:ring-offset-gray-950;
+  }
+
+  .app-text-muted {
+    @apply text-gray-600 dark:text-gray-300;
+  }
+
+  .app-label-caps {
+    @apply text-xs font-black uppercase tracking-[0.24em];
+  }
+
+  .app-code-panel {
+    @apply rounded-xl border border-white/10 bg-gray-950 p-3 text-sm text-gray-50;
+  }
+
+  .docs-code-blocks pre {
+    @apply border border-gray-800 bg-gray-950 text-gray-50 shadow-sm;
+  }
+
+  .docs-code-blocks pre code {
+    @apply bg-transparent p-0 text-gray-50;
+  }
+}
+
+/* Force fenced docs blocks to stay readable over Tailwind Typography and Pygments defaults. */
+.docs-code-blocks pre,
+.docs-code-blocks pre code,
+.docs-code-blocks pre code * {
+  color: #f8fafc !important;
+  opacity: 1 !important;
+}
+
+.docs-code-blocks pre,
+.docs-code-blocks pre code {
+  background-color: #020617 !important;
+}
+
+.docs-code-blocks pre code {
+  padding: 0 !important;
+  border-radius: 0 !important;
+  font-weight: 500 !important;
+}

--- a/{{ cookiecutter.project_slug }}/frontend/src/utils/clipboard.js
+++ b/{{ cookiecutter.project_slug }}/frontend/src/utils/clipboard.js
@@ -1,0 +1,26 @@
+export async function copyText(text) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      // Fall back for restricted clipboard contexts.
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  document.body.appendChild(textarea);
+  textarea.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch (error) {
+    return false;
+  } finally {
+    textarea.remove();
+  }
+}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_app.html
@@ -105,6 +105,13 @@
                     Dashboard
                   </a>
                 </li>
+                {% if cookiecutter.generate_docs == 'y' -%}
+                <li>
+                  <a href="{% raw %}{% url 'docs_home' %}{%- endraw %}" class="rounded-full px-6 py-3 text-base font-semibold leading-[1.7] tracking-[-0.09px] text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800">
+                    Docs
+                  </a>
+                </li>
+                {% endif %}
                 <li>
                   <a href="{% raw %}{% url 'settings' %}{%- endraw %}" class="rounded-full px-6 py-3 text-base font-semibold leading-[1.7] tracking-[-0.09px] text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800">
                     Settings
@@ -190,6 +197,13 @@
                     </a>
                   </li>
                   {{ "{% if user.is_authenticated %}" }}
+                  {% if cookiecutter.generate_docs == 'y' -%}
+                  <li class="py-5 text-center border-b border-gray-200 dark:border-gray-800">
+                    <a href="{% raw %}{% url 'docs_home' %}{%- endraw %}" class="text-sm font-semibold text-gray-900 hover:text-{{ cookiecutter.project_main_color }}-600 dark:text-gray-100 dark:hover:text-{{ cookiecutter.project_main_color }}-400">
+                      Docs
+                    </a>
+                  </li>
+                  {% endif %}
                   <li class="py-5 text-center border-b border-gray-200 dark:border-gray-800">
                     <a href="{% raw %}{% url 'settings' %}{%- endraw %}" class="text-sm font-semibold text-gray-900 hover:text-{{ cookiecutter.project_main_color }}-600 dark:text-gray-100 dark:hover:text-{{ cookiecutter.project_main_color }}-400">
                       Settings

--- a/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/base_landing.html
@@ -103,13 +103,6 @@
             <!-- Desktop Navigation -->
             <nav class="hidden lg:block">
               <ul class="flex gap-4 items-center">
-                {% if cookiecutter.generate_docs == 'y' -%}
-                <li>
-                  <a href="{% raw %}{% url 'docs_home' %}{%- endraw %}" class="rounded-full px-6 py-3 text-base font-semibold leading-[1.7] tracking-[-0.09px] text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800">
-                      Docs
-                    </a>
-                  </li>
-                {% endif %}
                 {% if cookiecutter.generate_blog == 'y' -%}
                 <li>
                   <a href="{% raw %}{% url 'blog_posts' %}{%- endraw %}" class="rounded-full px-6 py-3 text-base font-semibold leading-[1.7] tracking-[-0.09px] text-gray-900 transition-colors hover:bg-gray-100 dark:text-gray-100 dark:hover:bg-gray-800">
@@ -181,13 +174,6 @@
             <div data-dropdown-target="menu" class="hidden absolute right-4 left-4 top-full z-10 mt-2 bg-white rounded-2xl border border-gray-200 shadow-lg dark:bg-gray-900 dark:border-gray-800">
               <nav class="flex-1 justify-center items-center">
                 <ul class="flex flex-col px-4">
-                  {% if cookiecutter.generate_docs == 'y' -%}
-                  <li class="py-5 text-center border-b border-gray-200 dark:border-gray-800">
-                    <a href="{% raw %}{% url 'docs_home' %}{%- endraw %}" class="text-sm font-semibold text-gray-900 hover:text-{{ cookiecutter.project_main_color }}-600 dark:text-gray-100 dark:hover:text-{{ cookiecutter.project_main_color }}-400">
-                      Docs
-                    </a>
-                  </li>
-                  {% endif %}
                   {% if cookiecutter.generate_blog == 'y' -%}
                   <li class="py-5 text-center border-b border-gray-200 dark:border-gray-800">
                     <a href="{% raw %}{% url 'blog_posts' %}{%- endraw %}" class="text-sm font-semibold text-gray-900 hover:text-{{ cookiecutter.project_main_color }}-600 dark:text-gray-100 dark:hover:text-{{ cookiecutter.project_main_color }}-400">

--- a/{{ cookiecutter.project_slug }}/frontend/templates/docs/base_docs.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/docs/base_docs.html
@@ -1,61 +1,35 @@
-{{ "{% extends 'base_landing.html' %}" }}
+{{ "{% extends 'base_app.html' %}" }}
 
 {{ "{% block content %}" }}
-<div class="px-4 mx-auto max-w-[1400px] mt-16 sm:mt-24 lg:px-8" data-controller="toc">
+<div class="mx-auto max-w-[1400px] px-4 py-10 sm:px-6 lg:px-8" data-controller="toc docs-code">
   <div class="flex flex-col gap-8 xl:flex-row xl:gap-12">
-    <!-- Left Sidebar Navigation -->
-    <aside class="flex-shrink-0 xl:w-72">
-      <nav class="sticky top-8 pb-8 space-y-8">
+    <aside class="flex-shrink-0 xl:w-72" aria-label="Documentation sections">
+      <nav class="sticky top-24 space-y-8 pb-8">
 {% raw %}        {% for section in navigation %}{% endraw %}
-        <div class="space-y-3">
-          <h3 class="px-4 text-xs font-bold tracking-wider text-gray-500 uppercase">
-{% raw %}            {{ section.category }}{% endraw %}
-          </h3>
-          <ul class="space-y-1">
-{% raw %}            {% for page in section.pages %}{% endraw %}
-            <li>
-{% raw %}              <a href="{{ page.url }}"
-                 class="block px-4 py-2.5 text-[15px] leading-snug rounded-lg transition-all duration-150 {% if current_category == section.category_slug and current_page == page.slug %}bg-{{ cookiecutter.project_main_color }}-50 text-{{ cookiecutter.project_main_color }}-600 font-semibold shadow-sm{% else %}text-gray-700 hover:bg-gray-50 hover:text-gray-900 hover:pl-5{% endif %}">
-                {{ page.title }}{% endraw %}
-              </a>
-            </li>
+          <section class="space-y-3" aria-labelledby="docs-section-{{ '{{ forloop.counter }}' }}">
+            <h2 id="docs-section-{{ '{{ forloop.counter }}' }}" class="px-4 text-xs font-black uppercase tracking-[0.22em] text-gray-500 dark:text-gray-400">{{ '{{ section.category }}' }}</h2>
+            <ul class="space-y-1">
+{% raw %}              {% for page in section.pages %}{% endraw %}
+                <li>
+{% raw %}                  <a href="{{ page.url }}" class="app-focus block rounded-xl px-4 py-2.5 text-[15px] leading-snug transition {% if current_category == section.category_slug and current_page == page.slug %}bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-50 font-bold text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-700 shadow-sm dark:bg-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-950/40 dark:text-{% endraw %}{{ cookiecutter.project_main_color }}{% raw %}-300{% else %}text-gray-700 hover:bg-gray-100 hover:text-gray-950 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white{% endif %}">{{ page.title }}</a>{% endraw %}
+                </li>
 {{ "{% endfor %}" }}
-          </ul>
-        </div>
+            </ul>
+          </section>
 {{ "{% endfor %}" }}
       </nav>
     </aside>
 
-    <!-- Main Content -->
-    <main class="flex-1 min-w-0 max-w-4xl">
-      <!-- Work in Progress Notice -->
-      <div class="px-4 py-3 mb-6 text-sm text-blue-800 bg-blue-50 rounded-lg border border-blue-200">
-        <p class="flex gap-2 items-center mb-1">
-          <svg class="flex-shrink-0 w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-            <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd" />
-          </svg>
-          <span><strong>Work in Progress:</strong> This documentation is being actively developed. More content will be added soon!</span>
-        </p>
-        <p class="ml-7">
-          If you run into any issues, please email <a href="mailto:{{ cookiecutter.author_email }}" class="font-semibold underline hover:text-blue-900">{{ cookiecutter.author_email }}</a>
-        </p>
-      </div>
-
-      <article class="max-w-none prose prose-lg prose-gray prose-headings:font-semibold prose-headings:text-gray-900 prose-h1:text-4xl prose-h1:mb-4 prose-h2:text-3xl prose-h2:mt-8 prose-h2:mb-4 prose-h3:text-2xl prose-h3:mt-6 prose-h3:mb-3 prose-p:text-gray-700 prose-p:leading-relaxed prose-a:text-{{ cookiecutter.project_main_color }}-600 prose-a:no-underline hover:prose-a:underline prose-strong:text-gray-900 prose-strong:font-semibold prose-code:text-{{ cookiecutter.project_main_color }}-600 prose-code:bg-{{ cookiecutter.project_main_color }}-50 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-none prose-code:after:content-none prose-pre:bg-gray-900 prose-pre:text-gray-100 prose-pre:rounded-lg prose-pre:shadow-lg prose-ol:list-decimal prose-ol:pl-6 prose-ul:list-disc prose-ul:pl-6 prose-li:text-gray-700 docs-code-blocks" data-toc-target="content">
-        {{ "{% block docs_content %}" }}
-        {{ "{% endblock docs_content %}" }}
+    <main class="min-w-0 flex-1" id="docs-main-content">
+      <article class="prose prose-lg max-w-none prose-gray prose-headings:font-black prose-a:text-{{ cookiecutter.project_main_color }}-700 prose-a:no-underline hover:prose-a:underline prose-code:rounded prose-code:bg-transparent prose-code:px-0 prose-code:py-0 prose-code:text-gray-800 prose-code:before:content-none prose-code:after:content-none prose-pre:my-0 prose-pre:overflow-x-auto prose-pre:rounded-2xl prose-pre:bg-gray-950 prose-pre:p-5 prose-pre:pr-20 prose-pre:text-gray-100 prose-pre:shadow-sm dark:prose-invert dark:prose-a:text-{{ cookiecutter.project_main_color }}-300 dark:prose-code:bg-transparent dark:prose-code:text-gray-100 docs-code-blocks" data-toc-target="content">
+        {{ "{% block docs_content %}" }}{{ "{% endblock docs_content %}" }}
       </article>
     </main>
 
-    <!-- Right Sidebar Table of Contents -->
-    <aside class="hidden flex-shrink-0 xl:block xl:w-64" data-toc-target="sidebar">
-      <nav class="sticky top-8 space-y-4">
-        <h3 class="px-3 text-xs font-bold tracking-wider text-gray-500 uppercase">
-          On This Page
-        </h3>
-        <ul class="space-y-0" data-toc-target="list">
-          <!-- TOC items will be inserted here by JavaScript -->
-        </ul>
+    <aside class="hidden flex-shrink-0 xl:block xl:w-64" data-toc-target="sidebar" aria-label="Page table of contents">
+      <nav class="sticky top-24 space-y-4">
+        <h2 class="px-3 text-xs font-black uppercase tracking-[0.22em] text-gray-500 dark:text-gray-400">On this page</h2>
+        <ul class="space-y-0" data-toc-target="list"></ul>
       </nav>
     </aside>
   </div>

--- a/{{ cookiecutter.project_slug }}/frontend/templates/docs/docs_page.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/docs/docs_page.html
@@ -5,55 +5,32 @@
 {% raw %}<meta name="description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ page_title }} documentation for {% endraw %}{{ cookiecutter.project_name }}{% raw %}{% endif %}" />
 {% if meta_keywords %}<meta name="keywords" content="{{ meta_keywords }}" />{% endif %}
 {% if author %}<meta name="author" content="{{ author }}" />{% endif %}{% endraw %}
-<meta name="robots" content="index, follow" />
-{% raw %}{% if canonical_url %}
-<link rel="canonical" href="{{ canonical_url }}" />
-{% else %}
-<link rel="canonical" href="https://{{ request.get_host }}{% url 'docs_page' category=current_category page=current_page %}" />
-{% endif %}{% endraw %}
-
-<meta property="og:type" content="article" />
-<meta property="og:title" content="{{ "{{ page_title }}" }} - {{ "{{ category_title }}" }} | {{ cookiecutter.project_name }} Documentation" />
-{% raw %}<meta property="og:url" content="https://{{ request.get_host }}{% url 'docs_page' category=current_category page=current_page %}" />
-<meta property="og:description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ page_title }} documentation for {% endraw %}{{ cookiecutter.project_name }}{% raw %}{% endif %}" />{% endraw %}
-<meta property="og:site_name" content="{{ cookiecutter.project_name }}" />
-
-<meta name="twitter:card" content="summary" />
-<meta property="twitter:title" content="{{ "{{ page_title }}" }} - {{ "{{ category_title }}" }} | {{ cookiecutter.project_name }} Documentation" />
-{% raw %}<meta name="twitter:description" content="{% if meta_description %}{{ meta_description }}{% else %}{{ page_title }} documentation for {% endraw %}{{ cookiecutter.project_name }}{% raw %}{% endif %}" />{% endraw %}
+<meta name="robots" content="noindex, nofollow" />
+{% raw %}{% if canonical_url %}<link rel="canonical" href="{{ canonical_url }}" />{% endif %}{% endraw %}
 {{ "{% endblock meta %}" }}
 
 {{ "{% block docs_content %}" }}
-<h1>{{ "{{ page_title }}" }}</h1>
 {% raw %}{{ content|safe }}{% endraw %}
 
-<nav class="pt-8 mt-12 border-t border-gray-200 not-prose" aria-label="Docs pages navigation">
-    <div class="flex gap-4 justify-between">
-        <div class="flex-1">
-{% raw %}            {% if previous_page %}
-            <a href="{{ previous_page.url }}" class="block p-4 no-underline rounded-lg border border-gray-300 transition-colors group hover:border-gray-400">
-                <div class="mb-1 text-xs font-medium text-gray-500">
-                    ← Previous
-                </div>
-                <div class="text-base font-medium text-gray-700 group-hover:text-gray-900">
-                    {{ previous_page.page_title }}
-                </div>
-            </a>
-            {% endif %}{% endraw %}
-        </div>
-
-        <div class="flex-1">
-{% raw %}            {% if next_page %}
-            <a href="{{ next_page.url }}" class="block p-4 text-right no-underline rounded-lg border border-gray-300 transition-colors group hover:border-gray-400">
-                <div class="mb-1 text-xs font-medium text-gray-500">
-                    Next →
-                </div>
-                <div class="text-base font-medium text-gray-700 group-hover:text-gray-900">
-                    {{ next_page.page_title }}
-                </div>
-            </a>
-            {% endif %}{% endraw %}
-        </div>
+<nav class="not-prose mt-12 border-t border-gray-200 pt-8 dark:border-gray-800" aria-label="Docs pages navigation">
+  <div class="flex gap-4 justify-between">
+    <div class="flex-1">
+{% raw %}      {% if previous_page %}
+        <a href="{{ previous_page.url }}" class="app-focus block rounded-2xl border border-gray-200 p-4 no-underline transition hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:hover:border-gray-700 dark:hover:bg-gray-900">
+          <div class="mb-1 text-xs font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">← Previous</div>
+          <div class="text-base font-bold text-gray-800 dark:text-gray-100">{{ previous_page.page_title }}</div>
+        </a>
+      {% endif %}{% endraw %}
     </div>
+
+    <div class="flex-1">
+{% raw %}      {% if next_page %}
+        <a href="{{ next_page.url }}" class="app-focus block rounded-2xl border border-gray-200 p-4 text-right no-underline transition hover:border-gray-300 hover:bg-gray-50 dark:border-gray-800 dark:hover:border-gray-700 dark:hover:bg-gray-900">
+          <div class="mb-1 text-xs font-bold uppercase tracking-[0.18em] text-gray-500 dark:text-gray-400">Next →</div>
+          <div class="text-base font-bold text-gray-800 dark:text-gray-100">{{ next_page.page_title }}</div>
+        </a>
+      {% endif %}{% endraw %}
+    </div>
+  </div>
 </nav>
 {{ "{% endblock docs_content %}" }}

--- a/{{ cookiecutter.project_slug }}/frontend/templates/pages/home.html
+++ b/{{ cookiecutter.project_slug }}/frontend/templates/pages/home.html
@@ -1,28 +1,62 @@
 {{ '{% extends "base_app.html" %}' }}
 
 {{ "{% block content %}" }}
-<div class="isolate relative px-6 mt-16 sm:mt-24 lg:px-8">
-  <div class="mx-auto max-w-7xl">
-    <div class="mx-auto text-center">
-        <h1 class="mx-auto mb-6 max-w-2xl text-4xl font-bold tracking-tight text-gray-900 sm:text-5xl">
-          Welcome to {{ cookiecutter.project_name }}
-        </h1>
-        <p class="mt-6 text-lg leading-8 text-gray-600">
-          This is your main app dashboard. Start building your application here.
-        </p>
+<div class="mx-auto max-w-6xl px-4 py-10 sm:px-6 lg:px-8">
+  <div class="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+    <div>
+      <p class="app-label-caps text-{{ cookiecutter.project_main_color }}-600 dark:text-{{ cookiecutter.project_main_color }}-400">Dashboard</p>
+      <h1 class="mt-2 text-4xl font-black tracking-tight text-gray-900 dark:text-gray-100">Welcome to {{ cookiecutter.project_name }}</h1>
+      <p class="app-text-muted mt-4 max-w-2xl text-lg leading-8">
+        This is your main app dashboard. Start with a clear primary workflow, expose the next useful action, and keep project-specific setup close to where users need it.
+      </p>
     </div>
+    {% if cookiecutter.generate_docs == 'y' -%}
+    <a href="{% raw %}{% url 'docs_home' %}{%- endraw %}" class="app-button-secondary">View docs</a>
+    {% endif %}
   </div>
+
+  {% if cookiecutter.use_mcp == 'y' -%}
+  <section class="mb-10 rounded-3xl border border-{{ cookiecutter.project_main_color }}-200 bg-{{ cookiecutter.project_main_color }}-50 p-6 shadow-sm dark:border-{{ cookiecutter.project_main_color }}-900/60 dark:bg-{{ cookiecutter.project_main_color }}-950/30" aria-labelledby="agent-setup-heading">
+    <div class="flex flex-col gap-6 lg:flex-row lg:items-start lg:justify-between">
+      <div class="max-w-2xl">
+        <p class="app-label-caps text-{{ cookiecutter.project_main_color }}-700 dark:text-{{ cookiecutter.project_main_color }}-300">Agent setup</p>
+        <h2 id="agent-setup-heading" class="mt-2 text-2xl font-black text-gray-900 dark:text-gray-100">Teach your AI agent to use {{ cookiecutter.project_name }}</h2>
+        <p class="mt-3 text-sm leading-6 text-gray-700 dark:text-gray-300">
+          Copy this prompt into your coding agent. It includes the hosted MCP URL, REST user endpoint, API key, and a skill file the agent can read for setup instructions.
+        </p>
+        <p class="mt-2 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs leading-5 text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-100">
+          Treat this prompt like a password: it includes your API key. Use it only with agents you trust.
+        </p>
+      </div>
+      <a href="{{ '{{ agent_instructions_url }}' }}" class="app-button-secondary border-{{ cookiecutter.project_main_color }}-300 text-{{ cookiecutter.project_main_color }}-800 hover:bg-{{ cookiecutter.project_main_color }}-100 dark:border-{{ cookiecutter.project_main_color }}-800 dark:text-{{ cookiecutter.project_main_color }}-200 dark:hover:bg-{{ cookiecutter.project_main_color }}-950">
+        View agent skill
+      </a>
+    </div>
+
+    <div class="mt-6" data-controller="copy">
+      <label for="agent-setup-prompt" class="mb-2 block text-sm font-medium text-gray-900 dark:text-gray-100">Copy/paste prompt</label>
+      <textarea id="agent-setup-prompt" data-copy-target="source" readonly rows="10" aria-describedby="agent-setup-help" class="app-input block w-full border-{{ cookiecutter.project_main_color }}-200 p-4 font-mono text-xs leading-5 dark:border-{{ cookiecutter.project_main_color }}-900">{{ '{{ agent_setup_prompt }}' }}</textarea>
+      <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p id="agent-setup-help" class="text-xs leading-5 text-gray-600 dark:text-gray-400">Best path: remote MCP over HTTPS with the API key in an auth header. Query-string auth is only a fallback for clients that cannot send headers.</p>
+        <button type="button" data-action="copy#copy" class="app-button-primary">
+          <span data-copy-target="label">Copy prompt</span>
+        </button>
+      </div>
+    </div>
+  </section>
+  {% endif %}
+
+  <section class="app-card p-6" aria-labelledby="next-steps-heading">
+    <h2 id="next-steps-heading" class="text-xl font-bold text-gray-900 dark:text-gray-100">Next steps</h2>
+    <p class="app-text-muted mt-2 text-sm leading-6">Replace this card with the first high-value action in your product. Keep examples, API URLs, and implementation details in docs instead of crowding the dashboard.</p>
+  </section>
 </div>
 
 {% if cookiecutter.use_stripe == 'y' -%}
 {{ "{% if show_confetti %}" }}
 <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.5.1/dist/confetti.browser.min.js"></script>
 <script>
-  confetti({
-    particleCount: 100,
-    spread: 70,
-    origin: { y: 0.6 }
-  });
+  confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
 </script>
 {{ "{% endif %}" }}
 {% endif %}


### PR DESCRIPTION
## Summary
- upstream FileBridge-proven UI primitives into generated projects (`app-card`, button/input helpers, muted/caps/code panel patterns)
- move generated docs into authenticated app shell with noindex metadata, frontmatter-driven nav titles, API Reference section, and current-user/API-key markdown context
- add copy buttons plus forced high-contrast fenced-code styling for docs code blocks, including nested syntax-highlight spans
- add optional MCP dashboard setup prompt and improve generated `/SKILL.md`/MCP docs with explicit remote MCP + API verification flow

## Validation
- `uv run --group test pytest -q`
- generated MCP project via Cookiecutter
- generated project `npm install --include=dev --no-audit --no-fund && npm run lint && npm run build`
- generated project targeted Django tests attempted; blocked locally because no PostgreSQL server is running (`connection refused`), but generation/system check completed and template test suite covers rendered project structure
