### PR TITLE
[Deployment] Align uv Deployment Flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - remove djstripe. only use strip for payments
 - Use psycopg-binary instead of psycopg2-binary
 - If use_stripe is no. then make sure to remove everything
-- Use uv instead of poetry for pakage management.
+- Use uv instead of poetry for package management.
   - No need for requirements.txt file
 
 ### Fixed
@@ -86,6 +86,7 @@ and this project tries to adhere to [Semantic Versioning](https://semver.org/spe
 - Cookiecutter auth templates now include dark-mode friendly contrast updates
 - Cookiecutter settings template and confirm-email warning banner now include dark-mode friendly contrast updates
 - Cookiecutter auth templates (`login`, `signup`, `password_reset`) now include dark-mode friendly text/input/border styling
+- Keep Docker and Render deployments on uv and generate `uv.lock` during post-generation
 
 ## [0.0.5] - 2025-10-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ cookiecutter git@github.com:rasulkireev/django-saas-starter.git
 
 Then follow the generated project’s `README.md` for local development + deployment.
 
-Important: in generated projects, run `python manage.py makemigrations` (without app labels) before feature work so all app model changes are captured.
+Important: in generated projects, run `uv run python manage.py makemigrations` (without app labels) before feature work so all app model changes are captured.
 
 ## What you get (high level)
 
@@ -61,6 +61,7 @@ Important: in generated projects, run `python manage.py makemigrations` (without
 - ❓ Buttondown for newsletters
 
 ### Dev experience
+- ✅ Python dependency management with **uv** and a generated `uv.lock`
 - ✅ Docker Compose (local + prod)
 - ✅ Makefile helpers
 - ✅ pytest

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -2,6 +2,7 @@
 """Post-generation hook for cookiecutter-django-saas-starter."""
 
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -10,6 +11,7 @@ from pathlib import Path
 
 
 UV_VERSION = "0.11.15"
+UV_MIN_VERSION = tuple(int(part) for part in UV_VERSION.split("."))
 
 
 def remove_blog_app():
@@ -143,6 +145,7 @@ def generate_initial_migrations(uv_command):
             [
                 *uv_command,
                 "run",
+                "--locked",
                 "python",
                 "manage.py",
                 "makemigrations",
@@ -156,6 +159,24 @@ def generate_initial_migrations(uv_command):
     finally:
         settings_module_path.unlink(missing_ok=True)
         Path(".post_gen_migrations.sqlite3").unlink(missing_ok=True)
+
+
+def uv_version_tuple(version):
+    """Parse uv's numeric version prefix into a comparable tuple."""
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)", version)
+    if match is None:
+        return None
+
+    return tuple(int(part) for part in match.groups())
+
+
+def is_supported_uv_version(version):
+    """Return whether an installed uv can generate a compatible lock file."""
+    parsed_version = uv_version_tuple(version)
+    if parsed_version is None:
+        return False
+
+    return parsed_version >= UV_MIN_VERSION
 
 
 def valid_uv_command():
@@ -180,7 +201,7 @@ def valid_uv_command():
         return None
 
     installed_version = version_parts[1]
-    if installed_version != UV_VERSION:
+    if not is_supported_uv_version(installed_version):
         return None
 
     return [uv_path]
@@ -216,13 +237,13 @@ def install_uv(temp_dir):
 
 
 def ensure_uv_command():
-    """Return a pinned uv command, installing it temporarily if needed."""
+    """Return a compatible uv command, installing the minimum version if needed."""
     uv_command = valid_uv_command()
     if uv_command is not None:
         return uv_command, None
 
     print(
-        f"uv {UV_VERSION} not found; "
+        f"uv {UV_VERSION} or newer not found; "
         "installing it temporarily for post-generation tasks..."
     )
     temp_dir = tempfile.TemporaryDirectory()
@@ -247,9 +268,10 @@ def generate_uv_lock(uv_command):
             print("")
             print(exc.output)
         print(f"Original error: {exc}")
-        return
+        return False
 
     print("Generated uv.lock")
+    return True
 
 
 def main():
@@ -305,8 +327,11 @@ def main():
 
     try:
         if uv_command is not None:
-            generate_uv_lock(uv_command)
-            generate_initial_migrations(uv_command)
+            lock_generated = generate_uv_lock(uv_command)
+            if lock_generated:
+                generate_initial_migrations(uv_command)
+            else:
+                print("Skipping migration generation because uv.lock was not generated.")
     finally:
         if uv_temp_dir is not None:
             uv_temp_dir.cleanup()

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -4,7 +4,12 @@
 import os
 import shutil
 import subprocess
+import sys
+import tempfile
 from pathlib import Path
+
+
+UV_VERSION = "0.11.15"
 
 
 def remove_blog_app():
@@ -96,14 +101,17 @@ def remove_ci_workflow():
         print("Removed CI workflow")
 
 
-def generate_initial_migrations():
+def generate_initial_migrations(uv_command):
     """Generate fresh initial migrations after cookiecutter option cleanup."""
     if os.environ.get("SKIP_POST_GEN_MIGRATIONS") == "1":
         print("Skipping migration generation because SKIP_POST_GEN_MIGRATIONS=1")
         return
 
-    if shutil.which("uv") is None:
-        print("uv not found; run `uv run python manage.py makemigrations` after generation.")
+    if uv_command is None:
+        print(
+            f"uv {UV_VERSION} not available; "
+            "run `uv run python manage.py makemigrations` after generation."
+        )
         return
 
     env = os.environ.copy()
@@ -133,7 +141,7 @@ def generate_initial_migrations():
     try:
         subprocess.run(
             [
-                "uv",
+                *uv_command,
                 "run",
                 "python",
                 "manage.py",
@@ -148,6 +156,100 @@ def generate_initial_migrations():
     finally:
         settings_module_path.unlink(missing_ok=True)
         Path(".post_gen_migrations.sqlite3").unlink(missing_ok=True)
+
+
+def valid_uv_command():
+    """Return a working uv command if uv is already available."""
+    uv_path = shutil.which("uv")
+    if uv_path is None:
+        return None
+
+    try:
+        completed = subprocess.run(
+            [uv_path, "--version"],
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+    version_parts = completed.stdout.strip().split()
+    if len(version_parts) < 2:
+        return None
+
+    installed_version = version_parts[1]
+    if installed_version != UV_VERSION:
+        return None
+
+    return [uv_path]
+
+
+def run_quiet(command):
+    """Run a command, surfacing output only to callers handling failures."""
+    return subprocess.run(
+        command,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+    )
+
+
+def install_uv(temp_dir):
+    """Install uv into a temporary virtual environment and return its path."""
+    venv_path = Path(temp_dir) / "uv-bootstrap"
+    subprocess.run([sys.executable, "-m", "venv", str(venv_path)], check=True)
+
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    executable_suffix = ".exe" if os.name == "nt" else ""
+    python_path = venv_path / bin_dir / ("python" + executable_suffix)
+    uv_path = venv_path / bin_dir / ("uv" + executable_suffix)
+
+    run_quiet(
+        [str(python_path), "-m", "pip", "install", "--upgrade", "pip"],
+    )
+    run_quiet([str(python_path), "-m", "pip", "install", f"uv=={UV_VERSION}"])
+
+    return [str(uv_path)]
+
+
+def ensure_uv_command():
+    """Return a pinned uv command, installing it temporarily if needed."""
+    uv_command = valid_uv_command()
+    if uv_command is not None:
+        return uv_command, None
+
+    print(
+        f"uv {UV_VERSION} not found; "
+        "installing it temporarily for post-generation tasks..."
+    )
+    temp_dir = tempfile.TemporaryDirectory()
+    try:
+        return install_uv(temp_dir.name), temp_dir
+    except (OSError, subprocess.CalledProcessError):
+        temp_dir.cleanup()
+        raise
+
+
+def generate_uv_lock(uv_command):
+    """Generate uv.lock so Docker and hosted deployments work immediately."""
+    print("Generating uv.lock...")
+
+    try:
+        run_quiet([*uv_command, "lock"])
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print("")
+        print("WARNING: Could not generate uv.lock automatically.")
+        print("Install uv and run `uv lock` before committing or deploying this project.")
+        if isinstance(exc, subprocess.CalledProcessError) and exc.output:
+            print("")
+            print(exc.output)
+        print(f"Original error: {exc}")
+        return
+
+    print("Generated uv.lock")
 
 
 def main():
@@ -191,7 +293,23 @@ def main():
         remove_ci_workflow()
         print("CI cleanup complete!")
 
-    generate_initial_migrations()
+    uv_command = None
+    uv_temp_dir = None
+    try:
+        uv_command, uv_temp_dir = ensure_uv_command()
+    except (OSError, subprocess.CalledProcessError) as exc:
+        print("")
+        print("WARNING: Could not prepare uv for post-generation tasks.")
+        print("Install uv and run `uv lock` before committing or deploying this project.")
+        print(f"Original error: {exc}")
+
+    try:
+        if uv_command is not None:
+            generate_uv_lock(uv_command)
+            generate_initial_migrations(uv_command)
+    finally:
+        if uv_temp_dir is not None:
+            uv_temp_dir.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import json
 import subprocess
 import sys
@@ -65,6 +66,26 @@ def _assert_contains(path: Path, needle: str) -> None:
 def _assert_not_contains(path: Path, needle: str) -> None:
     content = _read_text(path)
     assert needle not in content, f"Expected not to find {needle!r} in {path}"
+
+
+def _post_gen_module():
+    hook_path = Path(__file__).resolve().parents[1] / "hooks" / "post_gen_project.py"
+    spec = importlib.util.spec_from_file_location("post_gen_project", hook_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_post_gen_accepts_newer_uv_versions() -> None:
+    module = _post_gen_module()
+
+    assert module.is_supported_uv_version("0.11.15")
+    assert module.is_supported_uv_version("0.12.0")
+    assert module.is_supported_uv_version("1.0.0")
+    assert not module.is_supported_uv_version("0.11.14")
+    assert not module.is_supported_uv_version("not-a-version")
 
 
 def test_cookiecutter_cli_generates_project_successfully(tmp_path: Path) -> None:

--- a/tests/test_cookiecutter_template.py
+++ b/tests/test_cookiecutter_template.py
@@ -133,6 +133,7 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     # sanity: core entrypoints exist
     assert (project_dir / "manage.py").exists()
     assert (project_dir / "pyproject.toml").exists()
+    assert (project_dir / "uv.lock").exists()
     assert (project_dir / "DESIGN.md").exists()
     assert (project_dir / "frontend" / "templates").exists()
 
@@ -190,7 +191,7 @@ def test_generate_default_structure(tmp_path: Path) -> None:
     assert (project_dir / "apps" / "blog" / "migrations" / "0001_initial.py").exists()
 
     _assert_contains(project_dir / "deployment" / "entrypoint.sh", "wait_for_database")
-    _assert_contains(project_dir / "deployment" / "entrypoint.sh", "exec gunicorn")
+    _assert_contains(project_dir / "deployment" / "entrypoint.sh", "exec uv run --no-sync gunicorn")
     _assert_contains(project_dir / "deployment" / "Dockerfile.server", "chmod +x deployment/entrypoint.sh")
     _assert_contains(project_dir / "deployment" / "Dockerfile.server", '["sh", "deployment/entrypoint.sh", "-s"]')
     _assert_contains(

--- a/{{ cookiecutter.project_slug }}/Dockerfile-python
+++ b/{{ cookiecutter.project_slug }}/Dockerfile-python
@@ -1,3 +1,7 @@
+ARG UV_VERSION=0.11.15
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM python:3.14.5
 
 WORKDIR /app
@@ -6,8 +10,8 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml uv.lock ./
-RUN pip install --upgrade pip && pip install --no-cache-dir uv
-RUN uv sync --frozen --no-dev --no-install-project
+COPY --from=uv /uv /uvx /bin/
+COPY pyproject.toml uv.lock .python-version ./
+RUN uv sync --locked --no-dev --no-install-project
 
 COPY . .

--- a/{{ cookiecutter.project_slug }}/Makefile
+++ b/{{ cookiecutter.project_slug }}/Makefile
@@ -6,19 +6,19 @@ serve:
 	docker compose -f docker-compose-local.yml logs -f backend
 
 shell:
-	docker compose -f docker-compose-local.yml run --rm backend python ./manage.py shell_plus --ipython
+	docker compose -f docker-compose-local.yml run --rm backend uv run --no-sync python ./manage.py shell_plus --ipython
 
 manage:
-	docker compose -f docker-compose-local.yml run --rm backend python ./manage.py $(filter-out $@,$(MAKECMDGOALS))
+	docker compose -f docker-compose-local.yml run --rm backend uv run --no-sync python ./manage.py $(filter-out $@,$(MAKECMDGOALS))
 
 makemigrations:
-	docker compose -f docker-compose-local.yml run --rm backend python ./manage.py makemigrations
+	docker compose -f docker-compose-local.yml run --rm backend uv run --no-sync python ./manage.py makemigrations
 
 migrate:
-	docker compose -f docker-compose-local.yml run --rm backend python ./manage.py migrate
+	docker compose -f docker-compose-local.yml run --rm backend uv run --no-sync python ./manage.py migrate
 
 test:
-	docker compose -f docker-compose-local.yml run --rm backend pytest $(filter-out $@,$(MAKECMDGOALS))
+	docker compose -f docker-compose-local.yml run --rm backend uv run --no-sync pytest $(filter-out $@,$(MAKECMDGOALS))
 
 restart-worker:
 	docker compose -f docker-compose-local.yml up -d workers --force-recreate

--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -159,11 +159,11 @@ Not recommended due to not being too safe for production and not being tested by
 
 If you are not into Docker or Render and just wanto to run this via regular commands you will need to have 5 processes running:
 {% if cookiecutter.use_mcp == 'y' -%}
-- `python manage.py collectstatic --noinput && python manage.py migrate && gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker`
+- `uv sync --locked --no-dev --no-install-project && uv run --no-sync python manage.py collectstatic --noinput && uv run --no-sync python manage.py migrate && uv run --no-sync gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker`
 {% else -%}
-- `python manage.py collectstatic --noinput && python manage.py migrate && gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2`
+- `uv sync --locked --no-dev --no-install-project && uv run --no-sync python manage.py collectstatic --noinput && uv run --no-sync python manage.py migrate && uv run --no-sync gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2`
 {% endif %}
-- `python manage.py qcluster`
+- `uv run --no-sync python manage.py qcluster`
 - `npm install && npm run start`
 - `postgres`
 - `redis`
@@ -195,6 +195,8 @@ You'd still need to make sure .env has correct values.
 6. Github Workflow in this repo should take care of the rest.
 
 ## Local Development
+
+`uv.lock` should be generated automatically when Cookiecutter creates this project. Commit it with the rest of the generated app. If it is missing, run `uv lock` once before deploying.
 
 1. Update the name of the `.env.example` to `.env` and update relevant variables.
 2. Run `uv sync`

--- a/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/render-deployment.md
+++ b/{{ cookiecutter.project_slug }}/apps/docs/content/deployment/render-deployment.md
@@ -9,6 +9,8 @@ author: {{ cookiecutter.author_name }}
 
 ## Required configuration
 
+This project deploys to Render with uv. `uv.lock` should be generated automatically when Cookiecutter creates the project, and it must be committed because Render enables uv for Python services when `uv.lock` exists at the service root.
+
 Before deploying, you need to configure environment variables. See the [Environment Variables](/docs/deployment/environment-variables/) guide for detailed information about all configuration options.
 
 Refer to the [Environment Variables](/docs/deployment/environment-variables/) guide for the complete list of required and optional variables.

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.server
@@ -1,3 +1,7 @@
+ARG UV_VERSION=0.11.15
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM node:24.15.0 AS build
 
 WORKDIR /app
@@ -14,11 +18,9 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml ./
-RUN pip install --no-cache-dir uv
-# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
-# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
-RUN uv sync --no-dev --no-install-project
+COPY --from=uv /uv /uvx /bin/
+COPY pyproject.toml uv.lock .python-version ./
+RUN uv sync --locked --no-dev --no-install-project
 
 COPY . .
 RUN chmod +x deployment/entrypoint.sh

--- a/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
+++ b/{{ cookiecutter.project_slug }}/deployment/Dockerfile.workers
@@ -1,3 +1,7 @@
+ARG UV_VERSION=0.11.15
+
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
 FROM node:24.15.0 AS build
 
 WORKDIR /app
@@ -14,11 +18,9 @@ ENV UV_PROJECT_ENVIRONMENT=/opt/venv
 ENV VIRTUAL_ENV=/opt/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-COPY pyproject.toml ./
-RUN pip install --no-cache-dir uv
-# NOTE: We intentionally don't require uv.lock here so freshly-generated projects build out of the box.
-# If you want fully reproducible builds, generate and commit a uv.lock in your rendered project, then add --frozen.
-RUN uv sync --no-dev --no-install-project
+COPY --from=uv /uv /uvx /bin/
+COPY pyproject.toml uv.lock .python-version ./
+RUN uv sync --locked --no-dev --no-install-project
 
 COPY . .
 RUN chmod +x deployment/entrypoint.sh

--- a/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
+++ b/{{ cookiecutter.project_slug }}/deployment/entrypoint.sh
@@ -23,7 +23,7 @@ shift $((OPTIND - 1))
 
 wait_for_database() {
     echo "Waiting for database..."
-    python - <<'PY'
+    uv run --no-sync python - <<'PY'
 import os
 import sys
 import time
@@ -54,14 +54,14 @@ wait_for_database
 
 if [ "$server" = true ]; then
     echo "Starting {{ cookiecutter.project_name }} server..."
-    python manage.py collectstatic --noinput
-    python manage.py migrate --noinput
+    uv run --no-sync python manage.py collectstatic --noinput
+    uv run --no-sync python manage.py migrate --noinput
     {% if cookiecutter.use_mcp == 'y' -%}
-    exec gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker
+    exec uv run --no-sync gunicorn ${PROJECT_NAME}.asgi:application --bind 0.0.0.0:80 --workers 3 --worker-class uvicorn_worker.UvicornWorker
     {% else -%}
-    exec gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
+    exec uv run --no-sync gunicorn ${PROJECT_NAME}.wsgi:application --bind 0.0.0.0:80 --workers 3 --threads 2
     {% endif %}
 else
     echo "Starting {{ cookiecutter.project_name }} workers..."
-    exec python manage.py qcluster
+    exec uv run --no-sync python manage.py qcluster
 fi

--- a/{{ cookiecutter.project_slug }}/docker-compose-local.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose-local.yml
@@ -30,7 +30,7 @@ services:
       context: .
       dockerfile: Dockerfile-python
     working_dir: /app
-    command: sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: sh -c "uv run --no-sync python manage.py migrate && uv run --no-sync python manage.py runserver 0.0.0.0:8000"
     volumes:
       - .:/app
     ports:
@@ -50,7 +50,7 @@ services:
       context: .
       dockerfile: Dockerfile-python
     working_dir: /app
-    command: python manage.py qcluster
+    command: uv run --no-sync python manage.py qcluster
     volumes:
       - .:/app
     depends_on:

--- a/{{ cookiecutter.project_slug }}/render.yaml
+++ b/{{ cookiecutter.project_slug }}/render.yaml
@@ -3,11 +3,11 @@ services:
     name: {{ cookiecutter.project_slug }}-web
     runtime: python
     buildCommand: |
-      pip install -r requirements.txt &&
-      npm ci &&
+      uv sync --locked --no-dev --no-install-project &&
+      npm install &&
       npm run build &&
-      python manage.py collectstatic --noinput
-    startCommand: python manage.py migrate && {% if cookiecutter.use_mcp == 'y' -%}gunicorn {{ cookiecutter.project_slug }}.asgi:application --bind 0.0.0.0:$PORT --workers 2 --worker-class uvicorn_worker.UvicornWorker --timeout 120{% else -%}gunicorn {{ cookiecutter.project_slug }}.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --threads 2 --timeout 120{% endif %}
+      uv run --no-sync python manage.py collectstatic --noinput
+    startCommand: uv run --no-sync python manage.py migrate && {% if cookiecutter.use_mcp == 'y' -%}uv run --no-sync gunicorn {{ cookiecutter.project_slug }}.asgi:application --bind 0.0.0.0:$PORT --workers 2 --worker-class uvicorn_worker.UvicornWorker --timeout 120{% else -%}uv run --no-sync gunicorn {{ cookiecutter.project_slug }}.wsgi:application --bind 0.0.0.0:$PORT --workers 2 --threads 2 --timeout 120{% endif %}
     plan: free
     healthCheckPath: /
 
@@ -53,8 +53,8 @@ services:
     name: {{ cookiecutter.project_slug }}-workers
     runtime: python
     buildCommand: |
-      pip install -r requirements.txt
-    startCommand: python manage.py qcluster & python -m http.server $PORT
+      uv sync --locked --no-dev --no-install-project
+    startCommand: uv run --no-sync python manage.py qcluster & uv run --no-sync python -m http.server $PORT
     plan: free
     healthCheckPath: /
 
@@ -118,6 +118,8 @@ envVarGroups:
         value: "24.15.0"
       - key: ENVIRONMENT
         value: prod
+      - key: UV_VERSION
+        value: "0.11.15"
       - key: DEBUG
         value: "False"
       - key: SECRET_KEY


### PR DESCRIPTION
## Summary

- Generate `uv.lock` during Cookiecutter post-generation using a pinned uv version.
- Update Docker, Render, local compose, Makefile, and production entrypoint commands to install and run Python dependencies through uv.
- Preserve the latest runtime alignment from `main` while keeping deployment builds locked and reproducible.
- Update template tests to assert generated projects include `uv.lock` and run Gunicorn through uv.

## Root Cause

The project had moved Python dependency management to uv, but deployment surfaces still disagreed: Docker expected a committed `uv.lock` that generated projects did not have, and Render still installed from `requirements.txt`, which no longer exists.

## Validation

- Rebased on latest `origin/main` (`66b33b2`).
- Resolved conflicts in runtime/deployment files from the runtime alignment changes.
- Ran `python3 -m py_compile hooks/post_gen_project.py`.
- Ran `git diff --check`.
- Ran full template test suite with pinned `uv==0.11.15`: `uv run --group test pytest`.
- Result: `29 passed in 257.21s`.